### PR TITLE
fix: ensure UTF-8 encoding for Windows compatibility

### DIFF
--- a/starforged/journal/exporter.py
+++ b/starforged/journal/exporter.py
@@ -94,7 +94,7 @@ def export_session(session: Session, character: Character) -> Path:
     lines.append(f"\n*Session {session.number} — {moves_count} moves, {oracles_count} oracles, {journal_count} journal entries*\n")
 
     content = "".join(lines)
-    path.write_text(content)
+    path.write_text(content, encoding="utf-8")
 
     return path
 
@@ -135,10 +135,10 @@ def append_to_journal(session: Session, character: Character) -> Path:
         if character.homeworld:
             header += f"- **Homeworld:** {character.homeworld}\n\n"
         header += "---\n"
-        path.write_text(header + content)
+        path.write_text(header + content, encoding="utf-8")
     else:
         # Append to existing journal
-        existing = path.read_text()
-        path.write_text(existing + content)
+        existing = path.read_text(encoding="utf-8")
+        path.write_text(existing + content, encoding="utf-8")
 
     return path

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -50,7 +50,7 @@ class TestExportSession:
     def test_uses_yaml_frontmatter(self, tmp_sessions, sample_character, sample_session):
         """Session export uses YAML frontmatter for metadata."""
         path = export_session(sample_session, sample_character)
-        content = path.read_text()
+        content = path.read_text(encoding="utf-8")
 
         # Should start with YAML frontmatter
         assert content.startswith("---\n")
@@ -72,7 +72,7 @@ class TestExportSession:
         path = export_session(sample_session, sample_character)
         assert path.name == "session_001.md"
 
-        content = path.read_text()
+        content = path.read_text(encoding="utf-8")
         assert "# Session 1\n" in content
         # No title field in frontmatter if empty
         assert "title:" not in content
@@ -80,7 +80,7 @@ class TestExportSession:
     def test_includes_session_entries(self, tmp_sessions, sample_character, sample_session):
         """Session export includes all journal entries."""
         path = export_session(sample_session, sample_character)
-        content = path.read_text()
+        content = path.read_text(encoding="utf-8")
 
         assert "I arrive at the abandoned mining station." in content
         assert "Face Danger (wits) → weak hit" in content
@@ -89,7 +89,7 @@ class TestExportSession:
     def test_includes_session_stats(self, tmp_sessions, sample_character, sample_session):
         """Session export includes footer with stats."""
         path = export_session(sample_session, sample_character)
-        content = path.read_text()
+        content = path.read_text(encoding="utf-8")
 
         assert "1 moves" in content
         assert "1 oracles" in content
@@ -98,7 +98,7 @@ class TestExportSession:
     def test_frontmatter_properly_closed(self, tmp_sessions, sample_character, sample_session):
         """Frontmatter has closing --- before markdown content."""
         path = export_session(sample_session, sample_character)
-        content = path.read_text()
+        content = path.read_text(encoding="utf-8")
 
         lines = content.split("\n")
         # Find both frontmatter delimiters


### PR DESCRIPTION
## Summary
- Explicitly specify `encoding='utf-8'` for all file I/O operations in journal exporter
- Fix test file reads to use UTF-8 encoding
- Resolves `UnicodeEncodeError` on Windows where default encoding is cp1252
- Ensures Unicode characters (→, —) in session exports work correctly

## Test plan
- [x] All 171 tests pass on Windows
- [x] Session exports with special characters work correctly
- [x] Manual verification: created PowerShell profile with `$env:PYTHONUTF8 = "1"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)