### PR TITLE
docs: clarify PR titles must use Conventional Commits format

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,13 @@
 - Use Conventional Commits: `feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`
 - Summary under 72 chars. Body explains *why*, not *what*.
 
+## Pull Requests
+
+- **PR titles MUST follow Conventional Commits format** (same as commit messages)
+- Examples: `feat: add character creation`, `fix: handle empty vow list`
+- Body should include Summary section (bullet points) and Test plan
+- Keep PR titles under 70 chars
+
 ## Code Quality
 
 - Run `make check` (lint + tests) before pushing.

--- a/docs/adr/001-repo-workflow-and-conventions.md
+++ b/docs/adr/001-repo-workflow-and-conventions.md
@@ -19,7 +19,9 @@ This is a personal project — a solo journaling CLI companion for Ironsworn: St
   - `docs/<short-description>` — documentation only
   - `chore/<short-description>` — tooling, CI, dependencies
 - Feature branches are merged into `main` via **pull requests**.
-- PRs should have a short title (<70 chars) and a body with a summary and test plan.
+- **PR titles MUST follow Conventional Commits format** (e.g., `feat: add session export`, `fix: handle Unicode on Windows`)
+- PR body should include a **Summary** section (bullet points) and **Test plan**
+- Keep PR titles under 70 chars
 - Delete feature branches after merge.
 
 ### Commit Messages


### PR DESCRIPTION
## Summary
- Add explicit "Pull Requests" section to CLAUDE.md stating PR titles must follow Conventional Commits
- Update ADR-001 to explicitly document PR title format requirements
- Previously this convention was only visible in git history, not documented

## Test plan
- [x] Documentation changes only, no code modified
- [x] Verified formatting and clarity of new sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)