### PR TITLE
feat: add --adventures-dir command-line argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,10 +152,16 @@ By default, all your adventure data is stored in `~/soloquest-adventures/`:
 - `sessions/` — individual session markdown
 - `journal/` — cumulative journal markdown
 
-**Configure your own location** to integrate with Obsidian, Logseq, or any personal wiki:
+**Use a custom location** to integrate with Obsidian, Logseq, or any personal wiki:
 
 ```bash
+# Option 1: Command-line argument (recommended)
+soloquest -d ~/Documents/ObsidianVault/Starforged
+soloquest --adventures-dir ./my-campaign
+
+# Option 2: Environment variable
 export SOLOQUEST_ADVENTURES_DIR="$HOME/Documents/ObsidianVault/Starforged"
+soloquest
 ```
 
 See [Adventures Directory Configuration](docs/adventures-directory.md) for details.

--- a/docs/adventures-directory.md
+++ b/docs/adventures-directory.md
@@ -20,9 +20,31 @@ By default, Starforged CLI stores all your adventure data (saves, sessions, jour
 
 ## Configuration
 
-### Option 1: Environment Variable (Recommended)
+The adventures directory can be configured in three ways (in priority order):
 
-Set `SOLOQUEST_ADVENTURES_DIR` to any directory:
+### Option 1: Command-Line Argument (Recommended)
+
+Pass the directory path directly when launching:
+
+```bash
+# Use short flag
+soloquest -d ~/Documents/ObsidianVault/Starforged
+
+# Or long flag
+soloquest --adventures-dir ~/my-campaigns
+
+# Relative paths work too
+soloquest -d ./test-campaign
+```
+
+**Benefits:**
+- ✅ Most explicit and clear
+- ✅ Easy to switch between campaigns
+- ✅ Works great with shell aliases
+
+### Option 2: Environment Variable
+
+Set `SOLOQUEST_ADVENTURES_DIR` in your shell:
 
 ```bash
 # In your ~/.bashrc or ~/.zshrc
@@ -32,7 +54,11 @@ export SOLOQUEST_ADVENTURES_DIR="$HOME/Documents/ObsidianVault/Starforged"
 SOLOQUEST_ADVENTURES_DIR="$HOME/my-campaigns" soloquest
 ```
 
-### Option 2: Default Location
+**Benefits:**
+- ✅ Set once, use everywhere
+- ✅ Good for a single primary campaign
+
+### Option 3: Default Location
 
 If no configuration is provided, adventures are stored in:
 - `~/soloquest-adventures/`
@@ -40,10 +66,11 @@ If no configuration is provided, adventures are stored in:
 ## Example: Obsidian Integration
 
 ```bash
-# Point to your Obsidian vault
-export SOLOQUEST_ADVENTURES_DIR="$HOME/Documents/ObsidianVault/TTRPG/Starforged"
+# Option A: Use command-line argument
+soloquest -d ~/Documents/ObsidianVault/TTRPG/Starforged
 
-# Run the CLI - sessions will appear in your vault automatically
+# Option B: Set environment variable
+export SOLOQUEST_ADVENTURES_DIR="$HOME/Documents/ObsidianVault/TTRPG/Starforged"
 soloquest
 ```
 
@@ -60,7 +87,12 @@ TTRPG/Starforged/
 
 ## Tips
 
-- **Use absolute paths** in `SOLOQUEST_ADVENTURES_DIR`
+- **Multiple campaigns?** Create shell aliases:
+  ```bash
+  alias starforged-main='soloquest -d ~/campaigns/starforged-main'
+  alias starforged-test='soloquest -d ~/campaigns/test-game'
+  ```
+- **Use absolute paths** for consistency
 - **Backup regularly** if storing in a cloud-synced folder
 - **Git-friendly** — Session markdown files are plain text and version-control friendly
 - **Share adventures** — Point multiple users to a shared network directory for collaborative worldbuilding

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -522,7 +522,7 @@ Debilities are lasting conditions that reduce your momentum:
 
 ### Session Export
 
-When you end a session with `/end`, the CLI creates a markdown file in your adventures directory (default: `~/Documents/Ironsworn/adventures/`).
+When you end a session with `/end`, the CLI creates a markdown file in your adventures directory (default: `~/soloquest-adventures/`).
 
 **Export includes:**
 - Session number and date
@@ -532,12 +532,16 @@ When you end a session with `/end`, the CLI creates a markdown file in your adve
 
 **Configuring adventures directory:**
 
-Create a `config.toml` file in `~/.config/soloquest/` (or platform equivalent):
+```bash
+# Option 1: Command-line argument (recommended)
+soloquest -d ~/Documents/ObsidianVault/Starforged
 
-```toml
-[adventures]
-directory = "/path/to/your/wiki/adventures"
+# Option 2: Environment variable
+export SOLOQUEST_ADVENTURES_DIR="$HOME/Documents/ObsidianVault/Starforged"
+soloquest
 ```
+
+See [Adventures Directory Configuration](adventures-directory.md) for more details.
 
 ---
 

--- a/soloquest/config.py
+++ b/soloquest/config.py
@@ -9,34 +9,53 @@ from pathlib import Path
 CONFIG_DIR = Path.home() / ".config" / "soloquest"
 CONFIG_FILE = CONFIG_DIR / "config.toml"
 
+# Global state for CLI-provided adventures directory
+_cli_adventures_dir: Path | None = None
+
+
+def set_adventures_dir(path: Path | str | None) -> None:
+    """
+    Set the adventures directory from CLI argument.
+
+    Args:
+        path: Path to adventures directory, or None to clear
+    """
+    global _cli_adventures_dir
+    _cli_adventures_dir = None if path is None else Path(path).expanduser().resolve()
+
 
 def get_adventures_dir() -> Path:
     """
     Get the adventures directory path.
 
     Priority order:
-    1. SOLOQUEST_ADVENTURES_DIR environment variable
-    2. Config file setting
-    3. Default: ~/soloquest-adventures
+    1. Command-line argument (--adventures-dir)
+    2. SOLOQUEST_ADVENTURES_DIR environment variable
+    3. Config file setting (future)
+    4. Default: ~/soloquest-adventures
 
     The adventures directory contains:
     - saves/      Character save files
     - sessions/   Individual session markdown
     - journal/    Cumulative journal markdown
     """
-    # 1. Check environment variable
+    # 1. Check CLI argument
+    if _cli_adventures_dir is not None:
+        return _cli_adventures_dir
+
+    # 2. Check environment variable
     env_path = os.environ.get("SOLOQUEST_ADVENTURES_DIR")
     if env_path:
         return Path(env_path).expanduser().resolve()
 
-    # 2. Check config file (if we add TOML support later)
+    # 3. Check config file (if we add TOML support later)
     # if CONFIG_FILE.exists():
     #     import tomllib
     #     config = tomllib.loads(CONFIG_FILE.read_text())
     #     if "adventures_dir" in config:
     #         return Path(config["adventures_dir"]).expanduser().resolve()
 
-    # 3. Default to ~/soloquest-adventures
+    # 4. Default to ~/soloquest-adventures
     return Path.home() / "soloquest-adventures"
 
 

--- a/soloquest/main.py
+++ b/soloquest/main.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import argparse
+from pathlib import Path
+
 from rich.prompt import Prompt
 
 from soloquest.engine.dice import DiceMode
@@ -82,8 +85,45 @@ def new_character() -> tuple[Character, list[Vow], DiceMode]:
     return character, vows, dice_mode
 
 
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        prog="soloquest",
+        description="A solo journaling CLI for tabletop RPGs",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  soloquest                                    # Use default directory
+  soloquest -d ~/my-campaigns                  # Use custom directory
+  soloquest --adventures-dir ./test-campaign   # Use relative path
+
+For more information: https://github.com/shawnoster/solo-cli
+        """,
+    )
+    parser.add_argument(
+        "-d",
+        "--adventures-dir",
+        type=Path,
+        metavar="PATH",
+        help="path to adventures directory (saves, sessions, journal)",
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version="%(prog)s 0.1.0",
+    )
+    return parser.parse_args()
+
+
 def main() -> None:
-    from soloquest.config import get_adventures_dir
+    from soloquest.config import get_adventures_dir, set_adventures_dir
+
+    # Parse command-line arguments
+    args = parse_args()
+
+    # Set adventures directory from CLI argument if provided
+    if args.adventures_dir:
+        set_adventures_dir(args.adventures_dir)
 
     display.splash()
 


### PR DESCRIPTION
## Summary

Adds a command-line argument for specifying the adventures directory, making it easier to switch between campaigns without modifying environment variables. This is a more user-friendly approach than requiring environment variable configuration.

## What's New

### Command-Line Argument: `-d` / `--adventures-dir`

```bash
# Short flag
soloquest -d ~/campaigns/starforged-main

# Long flag
soloquest --adventures-dir ~/my-campaigns

# Relative paths work
soloquest -d ./test-campaign
```

### Built-in Help

```bash
$ soloquest --help
usage: soloquest [-h] [-d PATH] [--version]

A solo journaling CLI for tabletop RPGs

options:
  -h, --help            show this help message and exit
  -d, --adventures-dir PATH
                        path to adventures directory (saves, sessions, journal)
  --version             show program's version number and exit

Examples:
  soloquest                                    # Use default directory
  soloquest -d ~/my-campaigns                  # Use custom directory
  soloquest --adventures-dir ./test-campaign   # Use relative path
```

## Configuration Priority

The adventures directory is resolved in this order (highest to lowest):

1. **Command-line argument** — `soloquest -d ~/my-campaigns` *(new!)*
2. **Environment variable** — `SOLOQUEST_ADVENTURES_DIR`
3. **Config file** — `~/.config/soloquest/config.toml` *(future)*
4. **Default** — `~/soloquest-adventures/`

## Use Cases

### Multiple Campaigns

Create shell aliases for different campaigns:

```bash
alias sf-main='soloquest -d ~/campaigns/starforged-main'
alias sf-test='soloquest -d ~/campaigns/test-game'
alias sf-oneshot='soloquest -d ~/campaigns/oneshots'
```

### Testing Without Affecting Main Campaign

```bash
# Test new features without touching your main campaign
soloquest -d ./test-campaign
```

### Obsidian Integration

```bash
# Point directly to your Obsidian vault
soloquest -d ~/Documents/ObsidianVault/TTRPG/Starforged
```

## Changes

### Code
- **soloquest/main.py**
  - Added `argparse` for command-line parsing
  - Added `-d` / `--adventures-dir` argument
  - Added `--version` flag
  - Added `--help` support with examples
  
- **soloquest/config.py**
  - Added `set_adventures_dir()` for CLI argument handling
  - Updated `get_adventures_dir()` to check CLI argument first
  - Updated priority order in docstring

### Documentation
- **README.md** — Added CLI argument examples in Adventures Directory section
- **docs/adventures-directory.md** — Complete rewrite with new priority order, shell alias examples
- **docs/getting-started.md** — Updated configuration examples

## Backwards Compatibility

✅ **Fully backwards compatible**
- Environment variable `SOLOQUEST_ADVENTURES_DIR` still works
- Default directory `~/soloquest-adventures/` unchanged
- No breaking changes to existing workflows

## Benefits

✅ **More intuitive** — No need to set environment variables  
✅ **Easier testing** — Quickly switch campaigns with a flag  
✅ **Better DX** — Shell aliases for campaign management  
✅ **Discoverable** — `--help` shows usage examples  
✅ **Flexible** — Mix CLI args with env vars as needed

## Test Plan

- [x] All 171 tests pass (`make check`)
- [x] Linting passes (ruff)
- [x] `--help` displays correctly
- [x] `-d` flag works with absolute paths
- [x] `--adventures-dir` flag works with relative paths
- [x] Environment variable still works as fallback
- [x] Default directory still works
- [x] Documentation updated

## Examples

```bash
# Use default directory
soloquest

# Switch to test campaign
soloquest -d ~/test

# Point to Obsidian vault
soloquest --adventures-dir ~/Documents/Obsidian/Starforged

# Shell aliases for multiple campaigns
alias main='soloquest -d ~/campaigns/main'
alias test='soloquest -d ~/campaigns/test'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)