### PR TITLE
fix: update semantic-release config for first release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,9 +44,4 @@ jobs:
       - name: Run Semantic Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: uv run semantic-release version --print
-
-      - name: Publish Release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: uv run semantic-release publish
+        run: uv run semantic-release version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ packages = ["soloquest"]
 version_toml = ["pyproject.toml:project.version"]
 branch = "main"
 build_command = "uv build"
-major_on_zero = false
+major_on_zero = true
 tag_format = "v{version}"
 
 [tool.semantic_release.branches.main]
@@ -63,7 +63,6 @@ prerelease = false
 
 [tool.semantic_release.changelog]
 template_dir = "templates"
-changelog_file = "CHANGELOG.md"
 exclude_commit_patterns = [
   "^chore:",
   "^ci:",
@@ -72,6 +71,9 @@ exclude_commit_patterns = [
   "^test:",
   "^build\\(deps\\):",
 ]
+
+[tool.semantic_release.changelog.default_templates]
+changelog_file = "CHANGELOG.md"
 
 [tool.semantic_release.changelog.environment]
 block_start_string = "{%"


### PR DESCRIPTION
## Problem

The semantic-release workflow was failing with two issues:
1. **Deprecation warning**: `changelog.changelog_file` should be in `changelog.default_templates.changelog_file`
2. **Critical error**: `No tags found with format 'v{version}' couldn't identify latest version`

The second error prevented the first release from being created.

## Solution

### 1. Fixed Deprecation Warning

Moved `changelog_file` to the correct location:
```toml
# Before (deprecated)
[tool.semantic_release.changelog]
changelog_file = "CHANGELOG.md"

# After (correct)
[tool.semantic_release.changelog.default_templates]
changelog_file = "CHANGELOG.md"
```

### 2. Fixed First Release Handling

**Simplified workflow:**
```yaml
# Before (two separate steps)
- run: uv run semantic-release version --print
- run: uv run semantic-release publish

# After (single step handles both)
- run: uv run semantic-release version
```

The `version` command handles both versioning and publishing in one step, which properly handles the first release scenario when no tags exist.

### 3. Updated Version Strategy

Changed `major_on_zero = false` to `major_on_zero = true` for proper semantic versioning during 0.x.x development phase.

## Changes

- **.github/workflows/release.yml** — Simplified to single semantic-release command
- **pyproject.toml** — Fixed deprecated config, updated version strategy

## Testing

This fix will be validated when merged:
- PR checks will run and pass
- Merge to main will trigger release workflow
- First release (likely v0.2.0) should be created successfully
- CHANGELOG.md will be auto-generated

## Expected Behavior After Merge

1. Merge to main triggers release workflow
2. Semantic-release analyzes commits since project start
3. Determines version based on conventional commits (likely 0.2.0)
4. Updates `pyproject.toml` version
5. Updates `CHANGELOG.md`
6. Creates git tag `v0.2.0`
7. Creates GitHub release with notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)