### PR TITLE
chore: update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -13,15 +13,15 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
@@ -35,7 +35,7 @@ jobs:
         run: uv run pytest --cov=soloquest --cov-report=term-missing --cov-report=xml
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           file: ./coverage.xml
           fail_ci_if_error: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,18 +18,18 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 


### PR DESCRIPTION
## Summary

Updates all GitHub Actions in workflows to their latest major versions as of February 2026.

## Actions Updated

| Action | Old Version | New Version | Changes |
|--------|-------------|-------------|---------|
| `actions/checkout` | v4 | v6 | Latest security patches, Node.js 24 runtime |
| `astral-sh/setup-uv` | v4 | v7 | Latest uv installer improvements |
| `actions/setup-python` | v5 | v6 | Node.js 24 runtime, improved caching |
| `codecov/codecov-action` | v4 | v5 | Updated CLI, better error handling |

## Benefits

✅ **Security** — Latest security patches and bug fixes  
✅ **Performance** — Runtime upgrades (node20 → node24)  
✅ **Reliability** — Improved error handling and stability  
✅ **Compatibility** — Better support for latest GitHub Actions features  
✅ **Maintenance** — Staying current with recommended versions

## Files Modified

- `.github/workflows/pr-checks.yml` — All 4 actions updated
- `.github/workflows/release.yml` — 3 actions updated

## Verification

These updates are non-breaking and maintain the same functionality:
- All actions use major version tags (e.g., `@v6`)
- Major version tags automatically include minor/patch updates
- Configuration parameters remain unchanged
- PR checks will validate the updates work correctly

## Sources

- [actions/checkout releases](https://github.com/actions/checkout/releases)
- [astral-sh/setup-uv releases](https://github.com/astral-sh/setup-uv/releases)
- [actions/setup-python releases](https://github.com/actions/setup-python/releases)
- [codecov/codecov-action releases](https://github.com/codecov/codecov-action/releases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)