### PR TITLE
fix: prevent double slash in tab completion

### DIFF
--- a/soloquest/commands/completion.py
+++ b/soloquest/commands/completion.py
@@ -35,7 +35,6 @@ class CommandCompleter(Completer):
     ) -> list[Completion]:
         """Return completions for the current input."""
         text = document.text_before_cursor
-        word = document.get_word_before_cursor()
 
         # Only complete if we're typing a command (starts with /)
         if not text.startswith("/"):
@@ -50,7 +49,8 @@ class CommandCompleter(Completer):
         for cmd in self.commands:
             if cmd.startswith(text.lower()):
                 # Calculate how many characters to complete
-                start_position = -len(word) if word else 0
+                # Use text (not word) to include the leading /
+                start_position = -len(text)
                 completions.append(
                     Completion(
                         text=cmd,

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -78,3 +78,18 @@ class TestCommandCompleter:
 
         assert len(completions) == 1
         assert completions[0].text == "/move"
+
+    def test_completion_replaces_entire_slash_command(self):
+        """Regression test: ensure completion replaces the full /cmd, not just cmd."""
+        completer = CommandCompleter()
+        # Simulate typing "/or" and tab-completing to "/oracle"
+        doc = Document("/or", cursor_position=3)
+        completions = list(completer.get_completions(doc, None))
+
+        # Find the /oracle completion (if it exists)
+        oracle_completions = [c for c in completions if c.text == "/oracle"]
+        if oracle_completions:
+            completion = oracle_completions[0]
+            # start_position should be -3 to replace all of "/or"
+            # This prevents the double-slash bug (//oracle)
+            assert completion.start_position == -3

--- a/uv.lock
+++ b/uv.lock
@@ -579,7 +579,7 @@ wheels = [
 
 [[package]]
 name = "soloquest"
-version = "1.0.0"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "prompt-toolkit" },


### PR DESCRIPTION
## Summary

- Fixed tab completion that caused double slashes (e.g., `/or` + tab → `//oracle`)
- Changed completion logic to use full text position instead of word position
- Added regression test to prevent future occurrences

## Test plan

- [x] All 180 existing tests pass
- [x] New regression test added (`test_completion_replaces_entire_slash_command`)
- [x] Linting passes (`make check`)
- [ ] Manual verification: type `/or`, press tab, verify it completes to `/oracle` (not `//oracle`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)