### PR TITLE
feat: add tab completion for oracle tables and moves

### DIFF
--- a/soloquest/commands/completion.py
+++ b/soloquest/commands/completion.py
@@ -2,19 +2,30 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from prompt_toolkit.completion import Completer, Completion
 from prompt_toolkit.document import Document
 
 from soloquest.commands.registry import COMMAND_ALIASES, COMMAND_HELP
 
+if TYPE_CHECKING:
+    from soloquest.engine.oracles import OracleTable
+
 
 class CommandCompleter(Completer):
-    """Completer for /commands with support for aliases."""
+    """Completer for /commands with support for aliases, oracle tables, and moves."""
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        oracles: dict[str, OracleTable] | None = None,
+        moves: dict | None = None,
+    ) -> None:
         # Build list of all commands (full names + aliases)
         self.commands: list[str] = []
         self.command_meta: dict[str, str] = {}
+        self.oracles = oracles or {}
+        self.moves = moves or {}
 
         # Add full command names with descriptions
         for cmd, help_text in COMMAND_HELP.items():
@@ -40,11 +51,15 @@ class CommandCompleter(Completer):
         if not text.startswith("/"):
             return []
 
-        # If we have spaces, only complete the first word (the command itself)
-        if " " in text.strip():
-            return []
+        # Check if we're completing arguments after a command
+        if " " in text:
+            return self._complete_arguments(text)
 
-        # Find matching commands
+        # Complete the command itself
+        return self._complete_command(text)
+
+    def _complete_command(self, text: str) -> list[Completion]:
+        """Complete slash command names."""
         completions = []
         for cmd in self.commands:
             if cmd.startswith(text.lower()):
@@ -58,5 +73,66 @@ class CommandCompleter(Completer):
                         display_meta=self.command_meta.get(cmd, ""),
                     )
                 )
+        return completions
 
+    def _complete_arguments(self, text: str) -> list[Completion]:
+        """Complete arguments for specific commands."""
+        # Parse out the command and current argument
+        parts = text.split()
+        if not parts:
+            return []
+
+        command = parts[0].lower()
+
+        # Get the current partial argument being typed
+        current_arg = text.split()[-1] if not text.endswith(" ") else ""
+
+        # Complete oracle tables
+        if command in ["/oracle", "/o"]:
+            return self._complete_oracle_tables(current_arg)
+
+        # Complete move names
+        if command in ["/move", "/m"]:
+            return self._complete_moves(current_arg)
+
+        return []
+
+    def _complete_oracle_tables(self, current_arg: str) -> list[Completion]:
+        """Complete oracle table names."""
+        completions = []
+        for key, table in self.oracles.items():
+            # Match against both key and name (show all if current_arg is empty)
+            if not current_arg or current_arg.lower() in key.lower() or current_arg.lower() in table.name.lower():
+                start_position = -len(current_arg) if current_arg else 0
+                # Prefer the key for completion, show the full name as meta
+                completions.append(
+                    Completion(
+                        text=key,
+                        start_position=start_position,
+                        display_meta=table.name,
+                    )
+                )
+        return completions
+
+    def _complete_moves(self, current_arg: str) -> list[Completion]:
+        """Complete move names."""
+        completions = []
+        for key, move_data in self.moves.items():
+            move_name = move_data.get("name", "")
+            # Match against both key and name (show all if current_arg is empty)
+            # Normalize for matching (spaces/underscores/hyphens)
+            key_normalized = key.replace("_", " ").replace("-", " ")
+            name_normalized = move_name.lower().replace("_", " ").replace("-", " ")
+            arg_normalized = current_arg.lower().replace("_", " ").replace("-", " ")
+
+            if not current_arg or arg_normalized in key_normalized or arg_normalized in name_normalized:
+                start_position = -len(current_arg) if current_arg else 0
+                # Prefer the key for completion, show the full name as meta
+                completions.append(
+                    Completion(
+                        text=key,
+                        start_position=start_position,
+                        display_meta=move_name,
+                    )
+                )
         return completions

--- a/soloquest/loop.py
+++ b/soloquest/loop.py
@@ -127,7 +127,7 @@ def run_session(
     display.console.print()
 
     history = InMemoryHistory()
-    completer = CommandCompleter()
+    completer = CommandCompleter(oracles=state.oracles, moves=state.moves)
     prompt_session: PromptSession = PromptSession(
         history=history,
         completer=completer,

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from prompt_toolkit.document import Document
 
 from soloquest.commands.completion import CommandCompleter
+from soloquest.engine.oracles import OracleTable
 
 
 class TestCommandCompleter:
@@ -93,3 +94,211 @@ class TestCommandCompleter:
             # start_position should be -3 to replace all of "/or"
             # This prevents the double-slash bug (//oracle)
             assert completion.start_position == -3
+
+
+class TestOracleTableCompletion:
+    def test_completes_oracle_table_names(self):
+        # Create mock oracle tables
+        oracles = {
+            "action": OracleTable(
+                key="action",
+                name="Action",
+                die="d100",
+                results=[(1, 100, "Test")],
+            ),
+            "theme": OracleTable(
+                key="theme",
+                name="Theme",
+                die="d100",
+                results=[(1, 100, "Test")],
+            ),
+        }
+        completer = CommandCompleter(oracles=oracles)
+        doc = Document("/oracle act", cursor_position=11)
+        completions = list(completer.get_completions(doc, None))
+
+        # Should match "action"
+        assert len(completions) >= 1
+        action_completions = [c for c in completions if c.text == "action"]
+        assert len(action_completions) == 1
+        # display_meta is a FormattedText, check if it contains the string
+        assert "Action" in str(action_completions[0].display_meta)
+
+    def test_completes_with_alias(self):
+        oracles = {
+            "pay_the_price": OracleTable(
+                key="pay_the_price",
+                name="Pay the Price",
+                die="d100",
+                results=[(1, 100, "Test")],
+            ),
+        }
+        completer = CommandCompleter(oracles=oracles)
+        # Using /o alias for /oracle
+        doc = Document("/o pay", cursor_position=6)
+        completions = list(completer.get_completions(doc, None))
+
+        assert len(completions) >= 1
+        pay_completions = [c for c in completions if c.text == "pay_the_price"]
+        assert len(pay_completions) == 1
+
+    def test_no_oracle_completion_for_other_commands(self):
+        oracles = {
+            "action": OracleTable(
+                key="action",
+                name="Action",
+                die="d100",
+                results=[(1, 100, "Test")],
+            ),
+        }
+        completer = CommandCompleter(oracles=oracles)
+        # /move should not complete oracle tables
+        doc = Document("/move act", cursor_position=9)
+        completions = list(completer.get_completions(doc, None))
+
+        # Should not get any completions for oracle tables after /move
+        assert len(completions) == 0
+
+    def test_oracle_completion_with_space_after_command(self):
+        oracles = {
+            "action": OracleTable(
+                key="action",
+                name="Action",
+                die="d100",
+                results=[(1, 100, "Test")],
+            ),
+        }
+        completer = CommandCompleter(oracles=oracles)
+        # Space after /oracle, cursor ready for table name
+        doc = Document("/oracle ", cursor_position=8)
+        completions = list(completer.get_completions(doc, None))
+
+        # Should show all oracle tables
+        assert len(completions) >= 1
+        action_completions = [c for c in completions if c.text == "action"]
+        assert len(action_completions) == 1
+
+    def test_oracle_completion_matches_by_name(self):
+        oracles = {
+            "pay_the_price": OracleTable(
+                key="pay_the_price",
+                name="Pay the Price",
+                die="d100",
+                results=[(1, 100, "Test")],
+            ),
+        }
+        completer = CommandCompleter(oracles=oracles)
+        # Search by part of the display name
+        doc = Document("/oracle price", cursor_position=13)
+        completions = list(completer.get_completions(doc, None))
+
+        # Should match because "price" is in "Pay the Price"
+        assert len(completions) >= 1
+        pay_completions = [c for c in completions if c.text == "pay_the_price"]
+        assert len(pay_completions) == 1
+
+
+class TestMoveCompletion:
+    def test_completes_move_names(self):
+        # Create mock moves
+        moves = {
+            "face_danger": {
+                "name": "Face Danger",
+                "category": "adventure",
+            },
+            "strike": {
+                "name": "Strike",
+                "category": "combat",
+            },
+        }
+        completer = CommandCompleter(moves=moves)
+        doc = Document("/move face", cursor_position=10)
+        completions = list(completer.get_completions(doc, None))
+
+        # Should match "face_danger"
+        assert len(completions) >= 1
+        face_completions = [c for c in completions if c.text == "face_danger"]
+        assert len(face_completions) == 1
+        # display_meta is a FormattedText, check if it contains the string
+        assert "Face Danger" in str(face_completions[0].display_meta)
+
+    def test_completes_move_with_alias(self):
+        moves = {
+            "secure_an_advantage": {
+                "name": "Secure an Advantage",
+                "category": "adventure",
+            },
+        }
+        completer = CommandCompleter(moves=moves)
+        # Using /m alias for /move
+        doc = Document("/m secure", cursor_position=9)
+        completions = list(completer.get_completions(doc, None))
+
+        assert len(completions) >= 1
+        secure_completions = [c for c in completions if c.text == "secure_an_advantage"]
+        assert len(secure_completions) == 1
+
+    def test_move_completion_normalizes_spaces(self):
+        moves = {
+            "face_danger": {
+                "name": "Face Danger",
+                "category": "adventure",
+            },
+        }
+        completer = CommandCompleter(moves=moves)
+        # Search with spaces instead of underscores
+        doc = Document("/move face danger", cursor_position=17)
+        completions = list(completer.get_completions(doc, None))
+
+        # Should still match because normalization handles spaces/underscores
+        assert len(completions) >= 1
+        face_completions = [c for c in completions if c.text == "face_danger"]
+        assert len(face_completions) == 1
+
+    def test_move_completion_matches_by_display_name(self):
+        moves = {
+            "strike": {
+                "name": "Strike",
+                "category": "combat",
+            },
+        }
+        completer = CommandCompleter(moves=moves)
+        # Search by display name
+        doc = Document("/move strike", cursor_position=12)
+        completions = list(completer.get_completions(doc, None))
+
+        assert len(completions) >= 1
+        strike_completions = [c for c in completions if c.text == "strike"]
+        assert len(strike_completions) == 1
+
+    def test_move_completion_with_space_after_command(self):
+        moves = {
+            "face_danger": {
+                "name": "Face Danger",
+                "category": "adventure",
+            },
+        }
+        completer = CommandCompleter(moves=moves)
+        # Space after /move, cursor ready for move name
+        doc = Document("/move ", cursor_position=6)
+        completions = list(completer.get_completions(doc, None))
+
+        # Should show all moves
+        assert len(completions) >= 1
+        face_completions = [c for c in completions if c.text == "face_danger"]
+        assert len(face_completions) == 1
+
+    def test_no_move_completion_for_other_commands(self):
+        moves = {
+            "strike": {
+                "name": "Strike",
+                "category": "combat",
+            },
+        }
+        completer = CommandCompleter(moves=moves)
+        # /oracle should not complete move names
+        doc = Document("/oracle strike", cursor_position=14)
+        completions = list(completer.get_completions(doc, None))
+
+        # Should not get move completions for /oracle
+        assert len(completions) == 0

--- a/uv.lock
+++ b/uv.lock
@@ -579,7 +579,7 @@ wheels = [
 
 [[package]]
 name = "soloquest"
-version = "1.1.0"
+version = "1.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "prompt-toolkit" },


### PR DESCRIPTION
## Summary

- Added tab completion for oracle table names after `/oracle` command
- Added tab completion for move names after `/move` command
- Supports command aliases (`/o` for oracle, `/m` for move)
- Fuzzy matching against both keys and display names
- Smart normalization for moves (handles spaces/underscores/hyphens)

## Examples

**Oracle completion:**
- `/oracle ` + Tab → shows all oracle tables
- `/oracle act` + Tab → completes to `action`
- `/oracle price` + Tab → finds `pay_the_price` by display name

**Move completion:**
- `/move ` + Tab → shows all moves
- `/move face` + Tab → completes to `face_danger`
- `/move face danger` + Tab → finds `face_danger` (space normalization)

## Test plan

- [x] All 191 tests pass (11 new tests added)
- [x] Linting passes (`make check`)
- [ ] Manual testing:
  - [ ] Type `/oracle ` and press tab, verify oracle tables appear
  - [ ] Type `/move ` and press tab, verify moves appear
  - [ ] Verify partial matching works for both
  - [ ] Verify aliases (`/o` and `/m`) work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)