### PR TITLE
feat: improve multi-oracle display with aligned columns

### DIFF
--- a/soloquest/ui/display.py
+++ b/soloquest/ui/display.py
@@ -107,20 +107,24 @@ def oracle_result_panel(table_name: str, roll: int, result: str) -> None:
 
 def oracle_result_panel_combined(results: list) -> None:
     """Display multiple oracle results in a single panel."""
+    # Build title with all table names on one line
+    table_names = " ".join(r.table_name.upper() for r in results)
+    title = f"[bold]ORACLE: {table_names}[/bold]"
+
+    # Calculate max table name width for alignment
+    max_name_width = max(len(r.table_name) for r in results)
+
+    # Build body with aligned columns
     lines = []
     for r in results:
-        lines.append(f"[bold]{r.table_name}[/bold]")
-        lines.append(f"[dim]{r.roll}[/dim]  →  [bold]{r.result}[/bold]")
-        lines.append("")  # blank line between results
-
-    # Remove trailing blank line
-    if lines and lines[-1] == "":
-        lines.pop()
+        # Pad table name to align columns
+        padded_name = r.table_name.ljust(max_name_width)
+        lines.append(
+            f"[bold]{padded_name}[/bold]   [dim]{r.roll:3d}[/dim]  →  [bold]{r.result}[/bold]"
+        )
 
     body = "\n".join(lines)
-    console.print(
-        Panel(body, title="[bold]ORACLE RESULTS[/bold]", border_style="bright_cyan")
-    )
+    console.print(Panel(body, title=title, border_style="bright_cyan"))
 
 
 def character_sheet(char: Character, vows: list[Vow], session_count: int, dice_mode: str) -> None:

--- a/tests/test_oracle_display.py
+++ b/tests/test_oracle_display.py
@@ -80,7 +80,11 @@ class TestOracleDisplay:
             # Verify it's a Panel with correct styling
             assert hasattr(panel_arg, "border_style")
             assert panel_arg.border_style == "bright_cyan"
-            assert "ORACLE RESULTS" in str(panel_arg.title)
+            # Title should show all table names: "ORACLE: ACTION THEME"
+            title_str = str(panel_arg.title)
+            assert "ORACLE:" in title_str
+            assert "ACTION" in title_str
+            assert "THEME" in title_str
 
             # Content should include both results
             content = str(panel_arg.renderable)
@@ -155,7 +159,9 @@ class TestOracleCommand:
 
         with (
             patch("soloquest.commands.oracle.roll_oracle", return_value=42),
-            patch("soloquest.commands.oracle.display.oracle_result_panel_combined") as mock_combined,
+            patch(
+                "soloquest.commands.oracle.display.oracle_result_panel_combined"
+            ) as mock_combined,
         ):
             handle_oracle(mock_state, args=["action", "theme"], flags=set())
 


### PR DESCRIPTION
## Summary

- Improve UX for multiple oracle rolls in a single command (e.g., `/oracle action theme`)
- Show all table names in the title on one line: "ORACLE: ACTION THEME"
- Display each result on a single line with aligned columns
- Makes multi-oracle results more compact and easier to scan

## Changes

- Modified `oracle_result_panel_combined()` in `soloquest/ui/display.py`:
  - Build title with all table names: `"ORACLE: {TABLE1 TABLE2 ...}"`
  - Calculate max table name width for column alignment
  - Pad table names with `ljust()` for alignment
  - Format roll numbers right-aligned with `:3d`
- Updated test to verify new title format includes all table names

## Display Format

**Before:**
```
┌─ ORACLE RESULTS ─────────┐
│ Action                   │
│ 42  →  Advance           │
│                          │
│ Theme                    │
│ 67  →  Mystery           │
└──────────────────────────┘
```

**After:**
```
┌─ ORACLE: ACTION THEME ───┐
│ Action    42  →  Advance │
│ Theme     67  →  Mystery │
└──────────────────────────┘
```

## Test plan

- [x] All 398 tests pass
- [x] Updated test verifies title includes all table names
- [x] Columns align correctly with different name lengths
- [x] Coverage maintained at 60%
- [x] Linting and formatting pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)