### PR TITLE
chore: configure cross-platform line endings and PowerShell support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,42 @@
+# Auto detect text files and normalize line endings to LF in the repository
+* text=auto
+
+# Explicitly declare text files you want to always be normalized and converted
+# to native line endings on checkout (CRLF on Windows, LF on macOS/Linux)
+*.py text eol=lf
+*.pyi text eol=lf
+*.toml text eol=lf
+*.yaml text eol=lf
+*.yml text eol=lf
+*.json text eol=lf
+*.md text eol=lf
+*.txt text eol=lf
+*.rst text eol=lf
+*.cfg text eol=lf
+*.ini text eol=lf
+
+# Shell scripts should always use LF (even on Windows via Git Bash)
+*.sh text eol=lf
+*.bash text eol=lf
+
+# Justfile should use LF
+justfile text eol=lf
+
+# Denote all files that are truly binary and should not be modified
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.pdf binary
+*.woff binary
+*.woff2 binary
+*.ttf binary
+*.eot binary
+*.gz binary
+*.zip binary
+*.pyc binary
+*.pyd binary
+*.so binary
+*.dll binary
+*.exe binary


### PR DESCRIPTION
## Summary
- Add `.gitattributes` to enforce LF line endings across Windows, macOS, and Ubuntu
- Update `justfile` for PowerShell compatibility on Windows
- Convert bash-specific recipes (`clean`, `branch`, `pr`) to PowerShell syntax
- Normalize existing repository files to LF

## Test plan
- [x] Verify `just` commands work in PowerShell on Windows
- [x] Confirm line endings are normalized to LF
- [ ] Test on macOS/Linux to ensure compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)