### PR TITLE
fix: correct roll_oracle import in Pay the Price handler

### DIFF
--- a/soloquest/commands/move.py
+++ b/soloquest/commands/move.py
@@ -284,7 +284,7 @@ def _offer_pay_the_price(state: GameState, flags: set[str]) -> None:
     """On a miss, offer to roll Pay the Price oracle."""
     display.console.print()
     if Confirm.ask("  Roll Pay the Price oracle?", default=True):
-        from soloquest.engine.oracles import roll_oracle
+        from soloquest.engine.dice import roll_oracle
 
         table = state.oracles.get("pay_the_price")
         if not table:


### PR DESCRIPTION
## Summary

- Fix import error when rolling Pay the Price oracle after a missed move
- The `roll_oracle` function is in `soloquest.engine.dice`, not `soloquest.engine.oracles`

## Bug Report

When a move results in a miss and the user chooses to roll the Pay the Price oracle, the game crashes with:
```
✗ Unexpected error: cannot import name 'roll_oracle' from 'soloquest.engine.oracles'
```

## Root Cause

In `soloquest/commands/move.py:287`, there was an incorrect import:
```python
from soloquest.engine.oracles import roll_oracle  # ❌ Wrong module
```

The `roll_oracle` function is actually defined in `soloquest.engine.dice`, not `soloquest.engine.oracles`.

## Changes

- Fixed import in `soloquest/commands/move.py:287`:
  ```python
  from soloquest.engine.dice import roll_oracle  # ✅ Correct module
  ```

## Test plan

- [x] All 398 tests pass
- [x] Linting passes
- [x] Formatting clean
- [x] Coverage maintained at 60%
- [x] Manual test: Pay the Price oracle now works correctly after a miss

🤖 Generated with [Claude Code](https://claude.com/claude-code)