### PR TITLE
fix: convert asset keys to CharacterAsset objects during character creation

### DIFF
--- a/soloquest/main.py
+++ b/soloquest/main.py
@@ -11,6 +11,7 @@ from rich.prompt import Prompt
 
 from soloquest.engine.assets import load_assets
 from soloquest.engine.dice import DiceMode
+from soloquest.models.asset import CharacterAsset
 from soloquest.models.character import Character, Stats
 from soloquest.models.vow import Vow, VowRank
 from soloquest.state.save import list_saves, load_game, load_most_recent
@@ -108,15 +109,18 @@ def new_character() -> tuple[Character, list[Vow], DiceMode] | None:
     display.console.print()
     display.info("  Choose 3 assets (type names, e.g. 'ace', 'empath', 'command_ship'):")
     display.info("  [dim]Press TAB for completion[/dim]")
-    assets: list[str] = []
-    while len(assets) < 3:
+    asset_keys: list[str] = []
+    while len(asset_keys) < 3:
         try:
-            raw = asset_session.prompt(f"  Asset {len(assets) + 1}: ")
+            raw = asset_session.prompt(f"  Asset {len(asset_keys) + 1}: ")
             if raw.strip():
-                assets.append(raw.strip().lower().replace(" ", "_"))
+                asset_keys.append(raw.strip().lower().replace(" ", "_"))
         except (KeyboardInterrupt, EOFError):
             display.console.print()
             return None
+
+    # Convert asset keys to CharacterAsset objects
+    assets = [CharacterAsset(asset_key=key) for key in asset_keys]
 
     character = Character(
         name=name,


### PR DESCRIPTION
## Summary

- Fixes AttributeError when using `/end` command to save character state
- Character creation was storing assets as strings instead of CharacterAsset objects
- Character.to_dict() expected CharacterAsset objects with .asset_key attribute
- Added conversion of asset keys to CharacterAsset objects immediately after collection
- Added regression test to prevent this bug from recurring

## Root Cause

During character creation in `main.py`, assets were collected as strings:
```python
assets: list[str] = []  # ❌ Storing as strings
```

But `Character.to_dict()` in `character.py` expected CharacterAsset objects:
```python
"assets": [
    {
        "asset_key": a.asset_key,  # ❌ Fails on strings
        ...
    }
    for a in self.assets
]
```

This caused: `AttributeError: 'str' object has no attribute 'asset_key'`

## Changes

**soloquest/main.py:**
- Import `CharacterAsset` model
- Rename `assets` to `asset_keys` for clarity
- Convert asset keys to CharacterAsset objects: `[CharacterAsset(asset_key=key) for key in asset_keys]`

**tests/test_character.py:**
- Add `test_serialization_with_assets` regression test
- Verifies characters with CharacterAsset objects can be serialized via to_dict()
- Tests both serialization and deserialization roundtrip

## Backward Compatibility

Existing save files remain compatible. `Character.from_dict()` already handles both:
- Old format: `["starship", "navigator"]` (strings)
- New format: `[{"asset_key": "starship", ...}]` (dicts)

## Test Plan

- [x] All 428 tests pass
- [x] Coverage maintained at 61% (character.py now 100%)
- [x] Pre-commit checks pass (format, lint, tests)
- [x] Regression test added to prevent recurrence
- [x] Manual verification: Create new character with assets and use `/end` command

🤖 Generated with [Claude Code](https://claude.com/claude-code)