### PR TITLE
refactor: reduce cognitive complexity across commands (SonarQube)

### DIFF
--- a/soloquest/commands/asset.py
+++ b/soloquest/commands/asset.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from soloquest.loop import GameState
 
 
-def handle_asset(state: GameState, args: list[str], flags: set[str]) -> None:
+def handle_asset(state: GameState, args: list[str], _flags: set[str]) -> None:
     """Display asset information or list available assets."""
     if not args:
         # List all assets by category

--- a/soloquest/commands/roll.py
+++ b/soloquest/commands/roll.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import random
 import re
 from typing import TYPE_CHECKING
 
@@ -53,8 +54,6 @@ def handle_roll(state: GameState, args: list[str], flags: set[str]) -> None:
             rolls.append(state.dice.roll(named))
         else:
             # Arbitrary die — always digital
-            import random
-
             rolls.append(random.randint(1, sides))
 
     total = sum(rolls)

--- a/tests/test_asset_display.py
+++ b/tests/test_asset_display.py
@@ -153,7 +153,7 @@ class TestAssetCommandIntegration:
         mock_state.assets = self.assets
 
         with patch("soloquest.commands.asset.display.console"):
-            handle_asset(mock_state, args=[], flags=set())
+            handle_asset(mock_state, args=[], _flags=set())
             # Should not raise exception
 
     def test_handle_asset_with_exact_match(self):
@@ -167,7 +167,7 @@ class TestAssetCommandIntegration:
         mock_state.assets = self.assets
 
         with patch("soloquest.commands.asset._display_asset_details") as mock_display:
-            handle_asset(mock_state, args=["starship"], flags=set())
+            handle_asset(mock_state, args=["starship"], _flags=set())
 
             # Should have called display with the starship asset
             mock_display.assert_called_once()
@@ -182,7 +182,7 @@ class TestAssetCommandIntegration:
         mock_state.assets = self.assets
 
         with patch("soloquest.commands.asset.display.error") as mock_error:
-            handle_asset(mock_state, args=["nonexistent_asset_xyz"], flags=set())
+            handle_asset(mock_state, args=["nonexistent_asset_xyz"], _flags=set())
 
             # Should have shown error
             mock_error.assert_called_once()
@@ -199,7 +199,7 @@ class TestAssetCommandIntegration:
         # Find a query that matches multiple assets
         # "engine" might match "engine_upgrade" and other engine-related assets
         with patch("soloquest.commands.asset.display.warn"):
-            handle_asset(mock_state, args=["module"], flags=set())
+            handle_asset(mock_state, args=["module"], _flags=set())
 
             # Might show warning if multiple matches
             # (This is implementation-dependent)

--- a/tests/test_oracle_display.py
+++ b/tests/test_oracle_display.py
@@ -7,6 +7,8 @@ of oracle results.
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from soloquest.commands.oracle import handle_oracle
 from soloquest.engine.oracles import OracleResult, OracleTable, load_oracles
 from soloquest.ui.display import oracle_result_panel, oracle_result_panel_combined
@@ -416,7 +418,7 @@ class TestOracleRangeCoverage:
             die="d100",
             results=[(1, 100, "Result")],
         )
-        assert coverage_percentage(full_table) == 100.0
+        assert coverage_percentage(full_table) == pytest.approx(100.0)
 
         # Partial coverage
         partial_table = OracleTable(
@@ -425,7 +427,7 @@ class TestOracleRangeCoverage:
             die="d100",
             results=[(1, 50, "Half")],
         )
-        assert coverage_percentage(partial_table) == 50.0
+        assert coverage_percentage(partial_table) == pytest.approx(50.0)
 
     def test_oracles_have_good_coverage(self):
         """Most oracles should have >90% coverage of their range."""


### PR DESCRIPTION
## Summary

- **asset**: rename unused `flags` → `_flags` parameter (S1172)
- **completion**: refactor `CommandCompleter` from complexity 30 → ≤15; extract `_normalize`, `_make_completion`, `_complete_options`, `_complete_move_categories`
- **move**: refactor `handle_move` (41→7), `fuzzy_match_move` (17→~9), `_handle_progress_roll` (25→5); extract `_parse_move_args`, `_display_no_match_error`, `_apply_dice_mode`, `_reset_dice_mode`, `_dispatch_move`, `_execute_action_roll`, `_maybe_burn_momentum`, `_select_vow`, `_resolve_progress_selection`
- **roll**: move `import random` to module level; PRNG use confirmed safe (game simulation only, no security context)
- **tests**: fix float equality with `pytest.approx` (S2184); update `handle_asset` call sites for renamed parameter

## Test plan

- [ ] `just check` passes (lint + 489 tests)
- [ ] No behaviour changes — purely structural refactoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)