### PR TITLE
fix: show Soloquest as primary title on startup

### DIFF
--- a/soloquest/__init__.py
+++ b/soloquest/__init__.py
@@ -1,3 +1,3 @@
-"""Ironsworn: Starforged CLI — solo journaling companion."""
+"""Soloquest — Ironsworn: Starforged solo journaling companion."""
 
 __version__ = "0.1.0"

--- a/soloquest/ui/display.py
+++ b/soloquest/ui/display.py
@@ -45,7 +45,7 @@ def splash() -> None:
     console.print()
     console.print(
         Panel(
-            "[bold white]IRONSWORN: STARFORGED[/bold white]\n[dim]The Forge awaits.[/dim]",
+            "[bold white]SOLOQUEST[/bold white]\n[dim]Ironsworn: Starforged companion[/dim]",
             border_style="blue",
             padding=(1, 4),
         )


### PR DESCRIPTION
## Summary

- Replaces `IRONSWORN: STARFORGED` in the startup splash with `SOLOQUEST`
- Keeps `Ironsworn: Starforged companion` as a dim subtitle for game attribution
- Updates module docstring in `__init__.py` to match

Closes #48

## Test plan

- [ ] Run `just run` and confirm splash shows `SOLOQUEST` with subtitle
- [ ] All 511 tests pass