### PR TITLE
fix: display human-readable asset names instead of internal keys

### DIFF
--- a/soloquest/commands/character.py
+++ b/soloquest/commands/character.py
@@ -18,6 +18,7 @@ def handle_char(state: GameState, args: list[str], flags: set[str]) -> None:
         state.character,
         state.vows,
         session_count=state.session_count,
+        assets=state.assets,
     )
 
 

--- a/soloquest/commands/new_character.py
+++ b/soloquest/commands/new_character.py
@@ -132,9 +132,8 @@ class AssetCompleter(Completer):
             ):
                 completions.append(
                     Completion(
-                        text=key,
+                        text=asset_name,
                         start_position=-len(current_arg) if current_arg else 0,
-                        display_meta=asset_name,
                     )
                 )
 
@@ -192,10 +191,10 @@ def _prompt_paths(available_assets: dict[str, Asset]) -> list[CharacterAsset] | 
                 display.error("  Path cannot be empty.")
                 continue
             if key not in paths:
-                display.error(f"  '{key}' is not a valid path. Try TAB for options.")
+                display.error(f"  '{raw.strip()}' is not a valid path. Try TAB for options.")
                 continue
             if key in chosen_paths:
-                display.error(f"  You already chose '{key}'. Pick a different path.")
+                display.error(f"  You already chose '{paths[key].name}'. Pick a different path.")
                 continue
             chosen_paths.append(key)
             break
@@ -225,7 +224,7 @@ def _prompt_final_asset(available_assets: dict[str, Asset]) -> CharacterAsset | 
             continue
         if key not in eligible:
             display.error(
-                f"  '{key}' is not available. Choose a path, module, companion, or support vehicle."
+                f"  '{raw.strip()}' is not available. Choose a path, module, companion, or support vehicle."
             )
             continue
         return CharacterAsset(asset_key=key)
@@ -408,7 +407,7 @@ def run_creation_wizard(data_dir: Path) -> tuple[Character, list[Vow], DiceMode]
         # ── Confirmation summary ─────────────────────────────────────────────
         display.console.print()
         asset_summary = "\n".join(
-            f"  • {a.asset_key.replace('_', ' ').title()}"
+            f"  • {available_assets[a.asset_key].name if a.asset_key in available_assets else a.asset_key.replace('_', ' ').title()}"
             + (f" ({a.input_values.get('name', '')})" if a.input_values.get("name") else "")
             for a in assets
         )

--- a/soloquest/ui/display.py
+++ b/soloquest/ui/display.py
@@ -134,7 +134,9 @@ def oracle_result_panel_combined(results: list) -> None:
         )
 
 
-def character_sheet(char: Character, vows: list[Vow], session_count: int) -> None:
+def character_sheet(
+    char: Character, vows: list[Vow], session_count: int, assets: dict | None = None
+) -> None:
     """Render full character sheet."""
     console.print()
     rule(char.name.upper())
@@ -235,7 +237,15 @@ def character_sheet(char: Character, vows: list[Vow], session_count: int) -> Non
     rule("Assets")
     if char.assets:
         console.print(
-            "  " + "  /  ".join(a.asset_key.replace("_", " ").title() for a in char.assets)
+            "  "
+            + "  /  ".join(
+                (
+                    assets[a.asset_key].name
+                    if assets and a.asset_key in assets
+                    else a.asset_key.replace("_", " ").title()
+                )
+                for a in char.assets
+            )
         )
     else:
         console.print("  [dim]No assets.[/dim]")

--- a/tests/test_character_commands.py
+++ b/tests/test_character_commands.py
@@ -29,6 +29,7 @@ class TestHandleChar:
             self.state.character,
             self.state.vows,
             session_count=5,
+            assets=self.state.assets,
         )
 
 

--- a/tests/test_character_creation.py
+++ b/tests/test_character_creation.py
@@ -33,28 +33,25 @@ class TestAssetCompleter:
 
         # Should have some matches for "ace"
         assert len(completions) > 0
-        # All matches should contain "ace" in key or name
+        # All matches should contain "ace" in the display name
         for completion in completions:
-            assert "ace" in completion.text.lower() or (
-                completion.display_meta and "ace" in completion.display_meta.lower()
-            )
+            assert "ace" in completion.text.lower()
 
     def test_completer_matches_asset_key(self):
-        """Should match against asset keys."""
+        """Typing a key should match and complete to the display name."""
         doc = Document("starship", cursor_position=8)
         completions = list(self.completer.get_completions(doc, None))
 
-        # Should find starship
-        assert any(c.text == "starship" for c in completions)
+        # Should find starship; completion text is the display name
+        assert any("Starship" in c.text for c in completions)
 
     def test_completer_matches_asset_name(self):
         """Should match against asset display names."""
-        # "Starship" is the display name for "starship" key
         doc = Document("star", cursor_position=4)
         completions = list(self.completer.get_completions(doc, None))
 
         # Should find starship by matching the name
-        assert any("starship" in c.text or "star" in c.text.lower() for c in completions)
+        assert any("star" in c.text.lower() for c in completions)
 
     def test_completions_are_alphabetically_sorted(self):
         """Completions should be returned in alphabetical order."""
@@ -68,27 +65,22 @@ class TestAssetCompleter:
         assert completion_texts == sorted(completion_texts)
 
     def test_completer_handles_underscores(self):
-        """Should handle underscores in asset names."""
+        """Typing a key with underscores should match and complete to display name."""
         doc = Document("crew_commander", cursor_position=14)
         completions = list(self.completer.get_completions(doc, None))
 
-        # Should find crew_commander
+        # Should find Crew Commander by display name
         assert len(completions) > 0
-        assert any(c.text == "crew_commander" for c in completions)
+        assert any("Crew Commander" in c.text for c in completions)
 
-    def test_completer_shows_display_meta(self):
-        """Completions should include display names as meta."""
+    def test_completer_shows_display_name_as_text(self):
+        """Completion text should be the human-readable display name."""
         doc = Document("starship", cursor_position=8)
         completions = list(self.completer.get_completions(doc, None))
 
-        # Find starship completion
-        starship_completion = next(c for c in completions if c.text == "starship")
-
-        # Should have display meta showing full name
-        assert starship_completion.display_meta
-        # display_meta can be a string or FormattedText, convert to string
-        meta_str = str(starship_completion.display_meta)
-        assert "Starship" in meta_str or "starship" in meta_str
+        # Completion text should be the display name, not the key
+        assert any(c.text == "Starship" for c in completions)
+        assert not any(c.text == "starship" for c in completions)
 
     def test_completer_case_insensitive(self):
         """Completion matching should be case-insensitive."""
@@ -103,13 +95,13 @@ class TestAssetCompleter:
         assert set(c.text for c in completions_lower) == set(c.text for c in completions_upper)
 
     def test_completer_handles_spaces_in_input(self):
-        """Should normalize spaces to underscores for matching."""
+        """Typing with spaces should match the display name."""
         doc = Document("crew commander", cursor_position=14)
         completions = list(self.completer.get_completions(doc, None))
 
-        # Should find crew_commander even with spaces
+        # Should find Crew Commander even with spaces
         assert len(completions) > 0
-        assert any(c.text == "crew_commander" for c in completions)
+        assert any("Crew Commander" in c.text for c in completions)
 
     def test_completer_with_no_matches(self):
         """Should return empty list when no assets match."""


### PR DESCRIPTION
## Summary

- Character sheet resolves `asset.name` from the assets dict rather than formatting the raw key
- Character creation confirmation summary uses `asset.name` from `available_assets`
- `AssetCompleter` now inserts the display name on tab-completion so users see and interact with human names throughout; input handlers normalize to keys internally for lookup
- Error messages show the user's original input rather than the normalized key

Closes #49

## Test plan

- [ ] `/char` — asset list shows "Bounty Hunter", "Crew Commander" etc. not `bounty_hunter`, `crew_commander`
- [ ] Tab-completing during character creation shows and inserts display names (e.g. "Bounty Hunter")
- [ ] Typing a key with underscores (e.g. `crew_commander`) still matches correctly
- [ ] Confirmation summary at end of wizard shows display names
- [ ] All 511 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)