### PR TITLE
chore: sync version to 2.2.0 after squash-merge history divergence

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "soloquest"
-version = "2.1.0"
+version = "2.2.0"
 description = "A solo journaling CLI for tabletop RPGs (Ironsworn: Starforged, Mythic GME, and more)"
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
## Summary

- Bumps `pyproject.toml` version from `2.1.0` → `2.2.0`

## Why

Semantic release is stuck because its v2.2.0 bump commit was orphaned. Here's what happened:

1. PSR ran after the `/guide` feature landed, created a bump commit `d36ca11` on top of that commit, tagged it `v2.2.0`, and pushed
2. Subsequent PRs were **squash-merged**, so their commits replaced the branch history — PSR's bump commit is no longer an ancestor of `main`
3. Every subsequent run: PSR reads `version = "2.1.0"` from `pyproject.toml`, calculates next version = `2.2.0`, sees the `v2.2.0` tag already exists, and exits with `No release will be made, 2.2.0 has already been released!`

Syncing `pyproject.toml` to `2.2.0` re-anchors PSR. On the next push to `main` it will read `2.2.0`, look for commits since the `v2.2.0` tag, find the accumulated `feat:` commits, and cut `v2.3.0`.

## Going forward

To prevent this recurring: consider switching to **merge commits** (instead of squash) for PRs, or adding `--no-vcs-release` / committing PSR's version bump via a separate protected step that can't be overwritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)