### PR TITLE
chore: update uv.lock to reflect version 2.2.0

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -579,7 +579,7 @@ wheels = [
 
 [[package]]
 name = "soloquest"
-version = "2.1.0"
+version = "2.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "prompt-toolkit" },


### PR DESCRIPTION
## Summary

- Updates `uv.lock` to reflect the `pyproject.toml` version bump from `2.1.0` → `2.2.0`

One-line change, keeping the lockfile in sync with the version sync from #57.

🤖 Generated with [Claude Code](https://claude.com/claude-code)