### PR TITLE
feat: add personal notes to campaign truths wizard

### DIFF
--- a/soloquest/models/truths.py
+++ b/soloquest/models/truths.py
@@ -47,6 +47,7 @@ class ChosenTruth:
     custom_text: str = ""
     quest_starter: str = ""
     subchoice: str = ""
+    note: str = ""
 
     def to_dict(self) -> dict:
         """Serialize to dictionary for JSON storage."""
@@ -57,6 +58,7 @@ class ChosenTruth:
             "custom_text": self.custom_text,
             "quest_starter": self.quest_starter,
             "subchoice": self.subchoice,
+            "note": self.note,
         }
 
     @classmethod
@@ -69,6 +71,7 @@ class ChosenTruth:
             custom_text=data.get("custom_text", ""),
             quest_starter=data.get("quest_starter", ""),
             subchoice=data.get("subchoice", ""),
+            note=data.get("note", ""),
         )
 
     def display_text(self) -> str:

--- a/tests/test_truths_model.py
+++ b/tests/test_truths_model.py
@@ -1,0 +1,55 @@
+"""Tests for the ChosenTruth model, including the note field."""
+
+from soloquest.models.truths import ChosenTruth
+
+
+class TestChosenTruthNote:
+    def test_note_defaults_to_empty_string(self):
+        truth = ChosenTruth(category="The Exodus", option_summary="Humanity fled")
+        assert truth.note == ""
+
+    def test_note_round_trips_through_dict(self):
+        truth = ChosenTruth(
+            category="The Exodus",
+            option_summary="Humanity fled",
+            note="This resonates with my character's backstory.",
+        )
+        restored = ChosenTruth.from_dict(truth.to_dict())
+        assert restored.note == "This resonates with my character's backstory."
+
+    def test_empty_note_round_trips(self):
+        truth = ChosenTruth(category="The Exodus", option_summary="Humanity fled")
+        restored = ChosenTruth.from_dict(truth.to_dict())
+        assert restored.note == ""
+
+    def test_from_dict_missing_note_defaults_to_empty(self):
+        """Existing saves without 'note' key should load without error."""
+        data = {
+            "category": "The Exodus",
+            "option_summary": "Humanity fled",
+            "option_text": "",
+            "custom_text": "",
+            "quest_starter": "",
+            "subchoice": "",
+        }
+        truth = ChosenTruth.from_dict(data)
+        assert truth.note == ""
+
+    def test_display_text_unaffected_by_note(self):
+        """display_text() returns summary+subchoice, note is kept separate."""
+        truth = ChosenTruth(
+            category="The Exodus",
+            option_summary="Humanity fled",
+            subchoice="via generation ships",
+            note="A personal aside.",
+        )
+        assert truth.display_text() == "Humanity fled (via generation ships)"
+
+    def test_custom_truth_display_text_unaffected(self):
+        truth = ChosenTruth(
+            category="Magic",
+            option_summary="Custom: no magic",
+            custom_text="Custom: no magic",
+            note="My campaign is hard sci-fi.",
+        )
+        assert truth.display_text() == "Custom: no magic"


### PR DESCRIPTION
## Summary

- Adds an optional personal note prompt after each truth is chosen in the wizard, asking *"What does this truth mean for your story?"*
- Notes are stored on `ChosenTruth.note`, serialized to JSON, and displayed dim-italic beneath each truth in `/truths show` and the end-of-wizard summary
- Old saves without the `note` field load cleanly via `.get("note", "")`
- Quest starter now appears after subchoices and immediately before the note prompt for better narrative flow
- Wrapped option text and quest starter text use `Padding` so indentation holds across line wraps
- Blank line added between "Quest Starter:" header and its description

## Test plan

- [ ] Run `/truths start` — after each choice, prompt reads *"What does this truth mean for your story? :"* with no `()` default shown
- [ ] Enter a note on some truths, skip others — summary at end shows notes indented below each truth
- [ ] Run `/truths show` — notes appear dim-italic under relevant truths
- [ ] Load an existing save (no `note` field in JSON) — no errors on load
- [ ] `just check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)