### PR TITLE
feat: polish character creation wizard UX

### DIFF
--- a/soloquest/commands/new_character.py
+++ b/soloquest/commands/new_character.py
@@ -158,18 +158,35 @@ def _prompt_paths(available_assets: dict[str, Asset]) -> list[CharacterAsset] | 
     path_session = PromptSession(completer=path_completer)
 
     display.console.print()
+    display.console.print(
+        "  [dim]Paths represent your background. Modules and companions come later.[/dim]"
+    )
+    display.console.print()
     display.info(
         "  Available path categories include: Archer, Ace, Empath, Infiltrator, and many more."
     )
-    display.info("  [dim]Press TAB to browse all paths.[/dim]")
 
-    # Offer background paths inspiration
+    # Show the full background paths table
+    display.console.print()
+    for idx, (_lo, _hi, background, suggestion) in enumerate(BACKGROUND_PATHS_TABLE, start=1):
+        display.console.print(f"  [dim][{idx:>2}][/dim]  {background:<28}[dim]{suggestion}[/dim]")
+    display.console.print()
+
+    # Inspiration prompt
     try:
-        suggest = Confirm.ask("  Roll for background path inspiration?", default=False)
+        raw = (
+            Prompt.ask(
+                "  Need inspiration? (1–20, r to roll, Enter to skip)",
+                default="",
+                show_default=False,
+            )
+            .strip()
+            .lower()
+        )
     except (KeyboardInterrupt, EOFError):
         return None
 
-    if suggest:
+    if raw == "r":
         result = _roll_table(BACKGROUND_PATHS_TABLE)
         roll, background, suggestion = result
         display.console.print(
@@ -179,6 +196,17 @@ def _prompt_paths(available_assets: dict[str, Asset]) -> list[CharacterAsset] | 
                 border_style="bright_cyan",
             )
         )
+    elif raw.isdigit():
+        idx = int(raw) - 1
+        if 0 <= idx < len(BACKGROUND_PATHS_TABLE):
+            lo, hi, background, suggestion = BACKGROUND_PATHS_TABLE[idx]
+            display.console.print(
+                Panel(
+                    f"[bold]{background}[/bold]\n[dim]Suggested paths: {suggestion}[/dim]",
+                    title="[bold]BACKGROUND PATHS[/bold]",
+                    border_style="bright_cyan",
+                )
+            )
 
     chosen_paths: list[str] = []
     for i in range(1, 3):
@@ -212,7 +240,6 @@ def _prompt_final_asset(available_assets: dict[str, Asset]) -> CharacterAsset | 
 
     display.console.print()
     display.info("  Choose your final asset — a path, module, companion, or support vehicle.")
-    display.info("  [dim]Press TAB to browse options.[/dim]")
 
     while True:
         try:
@@ -297,23 +324,22 @@ def run_creation_wizard(data_dir: Path) -> tuple[Character, list[Vow], DiceMode]
     display.console.print(
         "    • [bold]1 final asset[/bold] (path, module, companion, or support vehicle)"
     )
-    display.console.print()
-    display.console.print(
-        "  [dim]Paths represent your background. Modules and companions come later.[/dim]"
-    )
     display.console.print("  [dim]Press TAB at any asset prompt to browse options.[/dim]")
 
     try:
         available_assets = load_assets(data_dir)
 
         # ── Step 1: Choose 2 paths ──────────────────────────────────────────
+        display.console.print()
         display.rule("Step 1 — Choose 2 Paths")
+        display.console.print()
         path_assets = _prompt_paths(available_assets)
         if path_assets is None:
             display.console.print()
             return None
 
         # ── Step 2: Backstory ───────────────────────────────────────────────
+        display.console.print()
         display.rule("Step 2 — Backstory")
         display.console.print()
         _prompt_oracle_roll(BACKSTORY_TABLE, "Backstory")
@@ -321,6 +347,7 @@ def run_creation_wizard(data_dir: Path) -> tuple[Character, list[Vow], DiceMode]
         backstory = Prompt.ask("  Your backstory (or Enter to skip)", default="")
 
         # ── Step 3: Background vow ──────────────────────────────────────────
+        display.console.print()
         display.rule("Step 3 — Background Vow")
         display.console.print()
         display.info("  Every character begins with an Epic background vow.")
@@ -328,6 +355,7 @@ def run_creation_wizard(data_dir: Path) -> tuple[Character, list[Vow], DiceMode]
         vows = [Vow(description=bg_vow_text, rank=VowRank.EPIC)]
 
         # ── Step 4: STARSHIP ────────────────────────────────────────────────
+        display.console.print()
         display.rule("Step 4 — Board Your STARSHIP")
         display.console.print()
         display.info("  Your STARSHIP is auto-granted as a command vehicle.")
@@ -340,7 +368,9 @@ def run_creation_wizard(data_dir: Path) -> tuple[Character, list[Vow], DiceMode]
         )
 
         # ── Step 5: Final asset ─────────────────────────────────────────────
+        display.console.print()
         display.rule("Step 5 — Choose Final Asset")
+        display.console.print()
         final_asset = _prompt_final_asset(available_assets)
         if final_asset is None:
             display.console.print()
@@ -349,13 +379,16 @@ def run_creation_wizard(data_dir: Path) -> tuple[Character, list[Vow], DiceMode]
         assets = path_assets + [starship_asset, final_asset]
 
         # ── Step 6: Set stats ───────────────────────────────────────────────
+        display.console.print()
         display.rule("Step 6 — Set Stats")
+        display.console.print()
         stats = _prompt_stats()
         if stats is None:
             display.console.print()
             return None
 
         # ── Step 7: Condition meters (display only) ─────────────────────────
+        display.console.print()
         display.rule("Step 7 — Condition Meters")
         display.console.print()
         display.console.print(
@@ -371,6 +404,7 @@ def run_creation_wizard(data_dir: Path) -> tuple[Character, list[Vow], DiceMode]
         display.info("  These are set automatically.")
 
         # ── Step 8: Envision your character ─────────────────────────────────
+        display.console.print()
         display.rule("Step 8 — Envision Your Character")
         display.console.print()
         display.info("  All fields optional — press Enter to skip.")
@@ -379,6 +413,7 @@ def run_creation_wizard(data_dir: Path) -> tuple[Character, list[Vow], DiceMode]
         wear = Prompt.ask("  Wear (what you wear)", default="")
 
         # ── Step 9: Name your character ────────────────────────────────────
+        display.console.print()
         display.rule("Step 9 — Name Your Character")
         display.console.print()
         name = Prompt.ask("  Character name (or 'back' to cancel)")
@@ -389,6 +424,7 @@ def run_creation_wizard(data_dir: Path) -> tuple[Character, list[Vow], DiceMode]
         homeworld = Prompt.ask("  Homeworld or origin", default="")
 
         # ── Step 10: Gear up ────────────────────────────────────────────────
+        display.console.print()
         display.rule("Step 10 — Gear Up")
         display.console.print()
         display.console.print(
@@ -412,6 +448,7 @@ def run_creation_wizard(data_dir: Path) -> tuple[Character, list[Vow], DiceMode]
             gear.append(item)
 
         # ── Dice mode ───────────────────────────────────────────────────────
+        display.console.print()
         display.rule("Dice Mode")
         display.console.print()
         display.info("  How should dice be handled?")

--- a/soloquest/loop.py
+++ b/soloquest/loop.py
@@ -186,7 +186,6 @@ def run_session(
     is_new_session = session.number == session_count and len(session.entries) == 0
     resume_label = "" if is_new_session else " (Resumed)"
     display.session_header(session.number, resume_label)
-    display.info(f"  Character: {character.name}  |  Dice: {dice_mode.value}")
     display.info("  Type to journal. /guide for gameplay loop, /help for commands.")
 
     # Show context when resuming (not first session)

--- a/soloquest/ui/display.py
+++ b/soloquest/ui/display.py
@@ -43,16 +43,16 @@ def render_game_text(text: str) -> str:
 
 def splash(character: Character | None = None, vows: list[Vow] | None = None) -> None:
     if character:
-        name_line = character.name
+        title_line = f"[bold white]{character.name.upper()}[/bold white]"
         if character.callsign:
-            name_line += f"  [dim]«{character.callsign}»[/dim]"
+            title_line += f"  [dim]«{character.callsign}»[/dim]"
         stats_line = (
             f"[dim]Health[/dim] {character.health}/{TRACK_MAX}  "
             f"[dim]Spirit[/dim] {character.spirit}/{TRACK_MAX}  "
             f"[dim]Supply[/dim] {character.supply}/{TRACK_MAX}  "
             f"[dim]Momentum[/dim] {character.momentum:+d}"
         )
-        content = f"[bold white]SOLOQUEST[/bold white]\n[dim]{name_line}[/dim]\n{stats_line}"
+        content = f"{title_line}\n{stats_line}"
         active_vows = [v for v in (vows or []) if not v.fulfilled]
         if active_vows:
             vow_lines = "\n".join(

--- a/tests/test_new_character.py
+++ b/tests/test_new_character.py
@@ -76,7 +76,7 @@ class TestRunCreationWizard:
         """Run the wizard with mocked Prompt.ask and Confirm.ask answers."""
         if confirm_answers is None:
             # Default: skip all optional oracle rolls, confirm at end
-            confirm_answers = [False, False, False, False, True]
+            confirm_answers = [False, False, False, True]
 
         with (
             patch("soloquest.commands.new_character.Prompt.ask", side_effect=prompt_answers),
@@ -96,6 +96,8 @@ class TestRunCreationWizard:
     def test_wizard_returns_character_vows_dice_mode(self):
         """Successful completion returns a 3-tuple."""
         prompt_answers = [
+            # Step 1 inspiration (skip)
+            "",
             # Step 3 backstory
             "",
             # Step 4 background vow
@@ -132,6 +134,7 @@ class TestRunCreationWizard:
     def test_wizard_grants_starship_and_two_paths(self):
         """Character must have starship + 2 path assets + 1 free asset."""
         prompt_answers = [
+            "",  # inspiration (skip)
             "",  # backstory
             "Find the truth",  # vow
             "Rusty",  # ship name
@@ -168,6 +171,7 @@ class TestRunCreationWizard:
     def test_wizard_stores_ship_name_in_input_values(self):
         """STARSHIP asset input_values should contain the ship name."""
         prompt_answers = [
+            "",  # inspiration (skip)
             "",
             "Find the truth",
             "Stellar Drift",
@@ -197,6 +201,7 @@ class TestRunCreationWizard:
         from soloquest.models.vow import VowRank
 
         prompt_answers = [
+            "",  # inspiration (skip)
             "",
             "Avenge my homeworld",
             "",
@@ -225,6 +230,7 @@ class TestRunCreationWizard:
     def test_wizard_stores_narrative_fields(self):
         """Narrative fields (look, act, wear, pronouns, callsign, backstory) are stored."""
         prompt_answers = [
+            "",  # inspiration (skip)
             "Fled the war",  # backstory
             "Find the truth",  # vow
             "Ghost",  # ship name
@@ -256,6 +262,7 @@ class TestRunCreationWizard:
     def test_wizard_stores_gear(self):
         """Personal gear items are stored on the character."""
         prompt_answers = [
+            "",  # inspiration (skip)
             "",  # backstory
             "Find the truth",  # vow
             "",  # ship name
@@ -285,6 +292,7 @@ class TestRunCreationWizard:
     def test_wizard_supply_starts_at_5(self):
         """Character supply should start at 5 per rulebook."""
         prompt_answers = [
+            "",  # inspiration (skip)
             "",
             "Find the truth",
             "",
@@ -311,6 +319,7 @@ class TestRunCreationWizard:
     def test_wizard_cancellation_returns_none_on_back(self):
         """Typing 'back' at name prompt returns None."""
         prompt_answers = [
+            "",  # inspiration (skip)
             "",  # backstory
             "Find the truth",  # vow
             "",  # ship name
@@ -348,6 +357,7 @@ class TestRunCreationWizard:
     def test_wizard_dice_mode_physical(self):
         """Selecting '2' sets physical dice mode."""
         prompt_answers = [
+            "",  # inspiration (skip)
             "",
             "Find the truth",
             "",
@@ -374,6 +384,7 @@ class TestRunCreationWizard:
     def test_wizard_confirm_no_returns_none(self):
         """Declining the final confirmation returns None."""
         prompt_answers = [
+            "",  # inspiration (skip)
             "",
             "Find the truth",
             "",
@@ -393,7 +404,7 @@ class TestRunCreationWizard:
             "1",
         ]
         # Last confirm=False means cancel
-        confirm_answers = [False, False, False, False, False]
+        confirm_answers = [False, False, False, False]
         result = self._run_wizard_with_answers(prompt_answers, confirm_answers)
         assert result is None
 
@@ -421,6 +432,7 @@ class TestRunNewCharacterFlow:
 
     def _wizard_prompt_answers(self):
         return [
+            "",  # inspiration (skip)
             "",  # backstory
             "Find the truth",  # vow
             "Ghost",  # ship name
@@ -461,7 +473,7 @@ class TestRunNewCharacterFlow:
             ),
             patch(
                 "soloquest.commands.new_character.Confirm.ask",
-                side_effect=[False, False, False, False, True],
+                side_effect=[False, False, False, True],
             ),
             patch(
                 "soloquest.commands.new_character.PromptSession",


### PR DESCRIPTION
## Summary

- PC name (+ callsign) replaces "SOLOQUEST" as the title in the splash box on resume
- Remove redundant character info line above "Type to journal" — stats are already in the splash box
- Move "Paths represent your background..." from the overview into Step 1 context where it's relevant
- Show the full background paths table (all 20 entries, numbered) before the inspiration prompt
- Replace yes/no `Confirm` for inspiration with `"Need inspiration? (1–20, r to roll, Enter to skip)"` — pick by number, roll randomly, or skip inline
- Remove per-step "Press TAB" hints — stated once in the overview, no need to repeat
- Consistent blank line before and after every step rule for visual breathing room

## Test plan

- [ ] `just check` passes
- [ ] `just run` with existing save → splash shows PC name, no character line above prompt
- [ ] `just run --new` → character creation shows numbered background paths table; picking a number or `r` shows result panel; Enter skips
- [ ] Each step header has a blank line above and below
- [ ] Step 1 shows "Paths represent your background..." note before the table

🤖 Generated with [Claude Code](https://claude.com/claude-code)