### PR TITLE
feat: add asset meter & condition tracking

### DIFF
--- a/soloquest/commands/asset.py
+++ b/soloquest/commands/asset.py
@@ -2,39 +2,180 @@
 
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING
 
 from rich.panel import Panel
 
 from soloquest.engine.assets import fuzzy_match_asset
+from soloquest.models.asset import Asset, CharacterAsset
 from soloquest.ui import display
 
 if TYPE_CHECKING:
     from soloquest.loop import GameState
 
+_DELTA_RE = re.compile(r"^[+-]?\d+$")
+
 
 def handle_asset(state: GameState, args: list[str], _flags: set[str]) -> None:
-    """Display asset information or list available assets."""
+    """Display asset information, or view/update asset meters and conditions."""
     if not args:
-        # List all assets by category
         _list_assets(state)
         return
 
-    query = "_".join(args).lower()
-    matches = fuzzy_match_asset(query, state.assets)
+    # Try to resolve first arg against character's owned assets
+    result = _find_char_asset(state, args[0])
+    remaining = args[1:]
 
-    if not matches:
-        display.error(f"Asset not found: '{' '.join(args)}'")
-        display.info("Use /asset with no args to see all available assets.")
+    if result is None:
+        # Not a character asset — fall back to catalog lookup (read-only)
+        if remaining:
+            display.error(f"You don't own an asset matching '{args[0]}'.")
+            display.info("Use /asset with no args to see all available assets.")
+            return
+        query = "_".join(args).lower()
+        matches = fuzzy_match_asset(query, state.assets)
+        if not matches:
+            display.error(f"Asset not found: '{' '.join(args)}'")
+            display.info("Use /asset with no args to see all available assets.")
+            return
+        if len(matches) > 1:
+            names = ", ".join(a.name for a in matches)
+            display.warn(f"Multiple matches: {names}. Be more specific.")
+            return
+        _display_asset_details(matches[0])
         return
 
+    char_asset, asset_def = result
+
+    if not remaining:
+        # Show asset detail with live meter values and conditions
+        _display_char_asset_details(char_asset, asset_def)
+        return
+
+    # Parse remaining args to determine action
+    _handle_asset_mutation(state, char_asset, asset_def, remaining)
+
+
+def _find_char_asset(
+    state: GameState, query: str
+) -> tuple[CharacterAsset, Asset] | None:
+    """Find a character-owned asset matching the query.
+
+    Returns (CharacterAsset, Asset) on unique match, None if not found or ambiguous.
+    """
+    char = state.character
+    if not char or not char.assets:
+        return None
+
+    q = query.lower().replace(" ", "_").replace("-", "_")
+
+    exact: list[tuple[CharacterAsset, Asset]] = []
+    prefix: list[tuple[CharacterAsset, Asset]] = []
+    substring: list[tuple[CharacterAsset, Asset]] = []
+
+    for ca in char.assets:
+        asset_def = state.assets.get(ca.asset_key)
+        if asset_def is None:
+            continue
+        key = ca.asset_key.lower()
+        name_norm = asset_def.name.lower().replace(" ", "_")
+
+        if q in (key, name_norm):
+            exact.append((ca, asset_def))
+        elif key.startswith(q) or name_norm.startswith(q):
+            prefix.append((ca, asset_def))
+        elif q in key or q in name_norm:
+            substring.append((ca, asset_def))
+
+    matches = exact or prefix or substring
+
+    if len(matches) == 1:
+        return matches[0]
     if len(matches) > 1:
-        names = ", ".join(a.name for a in matches)
-        display.warn(f"Multiple matches: {names}. Be more specific.")
+        names = ", ".join(asset_def.name for _, asset_def in matches)
+        display.warn(f"Multiple asset matches: {names}. Be more specific.")
+        return None
+    return None
+
+
+def _handle_asset_mutation(
+    state: GameState,
+    char_asset: CharacterAsset,
+    asset_def: Asset,
+    remaining: list[str],
+) -> None:
+    """Parse remaining args after the asset name and apply meter/condition change."""
+    if len(remaining) == 1:
+        arg = remaining[0]
+        if _DELTA_RE.match(arg):
+            # /asset [name] [+/-N] — primary meter
+            _update_primary_meter(state, char_asset, asset_def, int(arg))
+        else:
+            # /asset [name] [condition] — toggle condition
+            _toggle_asset_condition(state, char_asset, asset_def, arg)
+    elif len(remaining) == 2:
+        meter_name, delta_str = remaining
+        if not _DELTA_RE.match(delta_str):
+            display.error(f"Expected a number for the delta, got '{delta_str}'.")
+            return
+        _update_named_meter(state, char_asset, asset_def, meter_name, int(delta_str))
+    else:
+        display.error("Usage: /asset [name] [+/-N | meter +/-N | condition]")
+
+
+def _update_primary_meter(
+    state: GameState, char_asset: CharacterAsset, asset_def: Asset, delta: int
+) -> None:
+    if not asset_def.tracks:
+        display.error(f"{asset_def.name} has no condition meters.")
+        return
+    track_name = next(iter(asset_def.tracks))
+    _update_named_meter(state, char_asset, asset_def, track_name, delta)
+
+
+def _update_named_meter(
+    state: GameState,
+    char_asset: CharacterAsset,
+    asset_def: Asset,
+    meter_name: str,
+    delta: int,
+) -> None:
+    """Find a track by (partial) name, then apply delta."""
+    q = meter_name.lower()
+    found = None
+    for tn in asset_def.tracks:
+        if tn == q or tn.startswith(q) or q in tn:
+            found = tn
+            break
+
+    if found is None:
+        available = ", ".join(asset_def.tracks.keys()) or "none"
+        display.error(
+            f"No meter '{meter_name}' on {asset_def.name}. Available: {available}"
+        )
         return
 
-    asset = matches[0]
-    _display_asset_details(asset)
+    min_val, max_val = asset_def.tracks[found]
+    old_val = char_asset.track_values.get(found, max_val)
+    new_val = char_asset.adjust_track(found, delta, min_val, max_val)
+
+    label = f"{asset_def.name} {found.title()}"
+    display.mechanical_update(f"{label} {old_val} → {new_val} ({delta:+d})")
+    state.session.add_mechanical(f"[{asset_def.name}] {found.title()} {old_val} → {new_val} ({delta:+d})")
+
+
+def _toggle_asset_condition(
+    state: GameState,
+    char_asset: CharacterAsset,
+    asset_def: Asset,
+    condition_name: str,
+) -> None:
+    is_active = char_asset.toggle_condition(condition_name)
+    status = "ON" if is_active else "cleared"
+    cond_display = condition_name.title()
+    display.mechanical_update(f"{asset_def.name}: {cond_display} {status}")
+    state.session.add_mechanical(f"[{asset_def.name}] Condition {cond_display}: {status}")
 
 
 def _list_assets(state: GameState) -> None:
@@ -60,36 +201,81 @@ def _list_assets(state: GameState) -> None:
         display.console.print(f"[bold]{category}:[/bold] {asset_names}")
 
 
-def _display_asset_details(asset) -> None:
-    """Display detailed information about an asset."""
-    from soloquest.models.asset import Asset
+def _display_char_asset_details(char_asset: CharacterAsset, asset_def: Asset) -> None:
+    """Display detailed asset info including live meter values and conditions."""
+    lines = []
 
+    category = asset_def.category.replace("_", " ").title()
+    lines.append(f"[dim]Category: {category}[/dim]")
+
+    if asset_def.shared:
+        lines.append("[dim]Shared Asset[/dim]")
+
+    if asset_def.inputs:
+        lines.append("")
+        lines.append(f"[bold]Inputs:[/bold] {', '.join(asset_def.inputs)}")
+        for field_name in asset_def.inputs:
+            val = char_asset.input_values.get(field_name.lower(), "")
+            if val:
+                lines.append(f"  [dim]«{val}»[/dim]")
+
+    if asset_def.tracks:
+        lines.append("")
+        lines.append("[bold]Condition Meters:[/bold]")
+        for track_name, (_min_val, max_val) in asset_def.tracks.items():
+            current = char_asset.track_values.get(track_name, max_val)
+            bar = display.make_track_bar(track_name.title(), current, max_val)
+            lines.append(f"  {bar}")
+
+    if char_asset.conditions:
+        lines.append("")
+        cond_str = "  ".join(
+            f"[bold red]{c.title()}[/bold red]" for c in sorted(char_asset.conditions)
+        )
+        lines.append(f"[bold]Conditions:[/bold]  {cond_str}")
+
+    if asset_def.abilities:
+        lines.append("")
+        lines.append("[bold]Abilities:[/bold]")
+        for i, ability in enumerate(asset_def.abilities, 1):
+            enabled_marker = "●" if ability.enabled else "○"
+            lines.append(
+                f"  {enabled_marker} [dim]{i}.[/dim] {display.render_game_text(ability.text)}"
+            )
+
+    body = "\n".join(lines)
+    display.console.print(
+        Panel(
+            body,
+            title=f"[bold]{asset_def.name.upper()}[/bold]",
+            border_style="bright_magenta",
+        )
+    )
+
+
+def _display_asset_details(asset: Asset) -> None:
+    """Display detailed information about a catalog asset."""
     if not isinstance(asset, Asset):
         return
 
-    # Build the panel content
     lines = []
 
-    # Category and shared status
     category = asset.category.replace("_", " ").title()
     lines.append(f"[dim]Category: {category}[/dim]")
 
     if asset.shared:
         lines.append("[dim]Shared Asset[/dim]")
 
-    # Inputs (custom fields)
     if asset.inputs:
         lines.append("")
         lines.append(f"[bold]Inputs:[/bold] {', '.join(asset.inputs)}")
 
-    # Condition meters/tracks
     if asset.tracks:
         lines.append("")
         lines.append("[bold]Condition Meters:[/bold]")
         for track_name, (min_val, max_val) in asset.tracks.items():
             lines.append(f"  • {track_name.title()}: {min_val}–{max_val}")
 
-    # Abilities
     if asset.abilities:
         lines.append("")
         lines.append("[bold]Abilities:[/bold]")

--- a/soloquest/commands/new_character.py
+++ b/soloquest/commands/new_character.py
@@ -18,6 +18,15 @@ from soloquest.models.character import Character, Stats
 from soloquest.models.vow import Vow, VowRank
 from soloquest.ui import display
 
+
+def _init_asset_tracks(char_asset: CharacterAsset, assets: dict[str, Asset]) -> None:
+    """Initialise track_values to max for all tracks not yet set."""
+    defn = assets.get(char_asset.asset_key)
+    if defn:
+        for track_name, (_, max_val) in defn.tracks.items():
+            if track_name not in char_asset.track_values:
+                char_asset.track_values[track_name] = max_val
+
 # ── Oracle tables (used only during character creation) ────────────────────────
 # Format: list of (min_roll, max_roll, text)
 
@@ -337,6 +346,8 @@ def run_creation_wizard(data_dir: Path) -> tuple[Character, list[Vow], DiceMode]
         if path_assets is None:
             display.console.print()
             return None
+        for ca in path_assets:
+            _init_asset_tracks(ca, available_assets)
 
         # ── Step 2: Backstory ───────────────────────────────────────────────
         display.console.print()
@@ -366,6 +377,7 @@ def run_creation_wizard(data_dir: Path) -> tuple[Character, list[Vow], DiceMode]
             asset_key="starship",
             input_values={"name": ship_name} if ship_name else {},
         )
+        _init_asset_tracks(starship_asset, available_assets)
 
         # ── Step 5: Final asset ─────────────────────────────────────────────
         display.console.print()
@@ -375,6 +387,7 @@ def run_creation_wizard(data_dir: Path) -> tuple[Character, list[Vow], DiceMode]
         if final_asset is None:
             display.console.print()
             return None
+        _init_asset_tracks(final_asset, available_assets)
 
         assets = path_assets + [starship_asset, final_asset]
 

--- a/soloquest/commands/registry.py
+++ b/soloquest/commands/registry.py
@@ -96,7 +96,7 @@ COMMAND_HELP: dict[str, str] = {
     "next": "/next — advance to next phase (guided mode only)",
     "move": "/move [name] (alias: /m) — resolve a move (e.g. /move strike)",
     "oracle": "/oracle [table] (alias: /o) — consult an oracle (e.g. /oracle action theme)",
-    "asset": "/asset [name] — view asset details (e.g. /asset starship)",
+    "asset": "/asset [name] [+/-N | meter +/-N | condition] — view or update asset meters/conditions",
     "vow": "/vow [rank] [text] (alias: /v) — create a vow",
     "progress": "/progress [vow] (alias: /p) — mark progress on a vow",
     "fulfill": "/fulfill [vow] (alias: /f) — attempt to fulfill a vow",

--- a/soloquest/loop.py
+++ b/soloquest/loop.py
@@ -64,6 +64,7 @@ AUTOSAVE_AFTER = {
     "debility",
     "forsake",
     "truths",
+    "asset",
 }
 
 

--- a/soloquest/models/asset.py
+++ b/soloquest/models/asset.py
@@ -41,10 +41,48 @@ class Asset:
 class CharacterAsset:
     """Instance of an asset owned by a character.
 
-    Stores the state of abilities (unlocked/enabled) and track values.
+    Stores the state of abilities (unlocked/enabled), track values, and conditions.
     """
 
     asset_key: str  # Reference to Asset definition
     abilities_unlocked: list[bool] = field(default_factory=list)  # [True, False, False]
     track_values: dict[str, int] = field(default_factory=dict)  # {"health": 2}
     input_values: dict[str, str] = field(default_factory=dict)  # {"name": "Rusty"}
+    conditions: set[str] = field(default_factory=set)  # {"battered"}
+
+    def to_dict(self) -> dict:
+        return {
+            "asset_key": self.asset_key,
+            "abilities_unlocked": self.abilities_unlocked,
+            "track_values": self.track_values,
+            "input_values": self.input_values,
+            "conditions": sorted(self.conditions),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict | str) -> CharacterAsset:
+        if isinstance(data, str):
+            return cls(asset_key=data)
+        return cls(
+            asset_key=data["asset_key"],
+            abilities_unlocked=data.get("abilities_unlocked", []),
+            track_values=data.get("track_values", {}),
+            input_values=data.get("input_values", {}),
+            conditions=set(data.get("conditions", [])),
+        )
+
+    def adjust_track(self, name: str, delta: int, min_val: int, max_val: int) -> int:
+        """Adjust meter by delta, clamped to [min_val, max_val]. Returns new value."""
+        current = self.track_values.get(name, max_val)
+        new_val = max(min_val, min(max_val, current + delta))
+        self.track_values[name] = new_val
+        return new_val
+
+    def toggle_condition(self, name: str) -> bool:
+        """Toggle a condition. Returns True if now active."""
+        name_lower = name.lower()
+        if name_lower in self.conditions:
+            self.conditions.discard(name_lower)
+            return False
+        self.conditions.add(name_lower)
+        return True

--- a/soloquest/models/character.py
+++ b/soloquest/models/character.py
@@ -139,15 +139,7 @@ class Character:
             "supply": self.supply,
             "momentum": self.momentum,
             "debilities": sorted(self.debilities),
-            "assets": [
-                {
-                    "asset_key": a.asset_key,
-                    "abilities_unlocked": a.abilities_unlocked,
-                    "track_values": a.track_values,
-                    "input_values": a.input_values,
-                }
-                for a in self.assets
-            ],
+            "assets": [a.to_dict() for a in self.assets],
             "truths": [t.to_dict() for t in self.truths],
             "pronouns": self.pronouns,
             "callsign": self.callsign,
@@ -164,21 +156,7 @@ class Character:
 
         # Handle both old format (list[str]) and new format (list[dict])
         assets_data = data.get("assets", [])
-        assets = []
-        for item in assets_data:
-            if isinstance(item, str):
-                # Old format: just asset keys
-                assets.append(CharacterAsset(asset_key=item))
-            elif isinstance(item, dict):
-                # New format: full CharacterAsset data
-                assets.append(
-                    CharacterAsset(
-                        asset_key=item.get("asset_key", ""),
-                        abilities_unlocked=item.get("abilities_unlocked", []),
-                        track_values=item.get("track_values", {}),
-                        input_values=item.get("input_values", {}),
-                    )
-                )
+        assets = [CharacterAsset.from_dict(item) for item in assets_data]
 
         # Handle truths
         truths_data = data.get("truths", [])

--- a/tests/models/test_asset_model.py
+++ b/tests/models/test_asset_model.py
@@ -1,0 +1,128 @@
+"""Tests for CharacterAsset model helpers (adjust_track, toggle_condition, serialisation)."""
+
+from __future__ import annotations
+
+from soloquest.models.asset import CharacterAsset
+
+
+class TestAdjustTrack:
+    def test_decrements_within_range(self):
+        ca = CharacterAsset(asset_key="starship", track_values={"integrity": 5})
+        result = ca.adjust_track("integrity", -2, 0, 5)
+        assert result == 3
+        assert ca.track_values["integrity"] == 3
+
+    def test_increments_within_range(self):
+        ca = CharacterAsset(asset_key="starship", track_values={"integrity": 2})
+        result = ca.adjust_track("integrity", +2, 0, 5)
+        assert result == 4
+        assert ca.track_values["integrity"] == 4
+
+    def test_clamps_at_min(self):
+        ca = CharacterAsset(asset_key="starship", track_values={"integrity": 1})
+        result = ca.adjust_track("integrity", -10, 0, 5)
+        assert result == 0
+        assert ca.track_values["integrity"] == 0
+
+    def test_clamps_at_max(self):
+        ca = CharacterAsset(asset_key="starship", track_values={"integrity": 4})
+        result = ca.adjust_track("integrity", +10, 0, 5)
+        assert result == 5
+        assert ca.track_values["integrity"] == 5
+
+    def test_defaults_to_max_when_track_not_set(self):
+        ca = CharacterAsset(asset_key="starship")
+        result = ca.adjust_track("integrity", -1, 0, 5)
+        assert result == 4  # started at max (5), decremented by 1
+
+    def test_exact_boundary_min(self):
+        ca = CharacterAsset(asset_key="bot", track_values={"health": 0})
+        result = ca.adjust_track("health", -1, 0, 5)
+        assert result == 0
+
+    def test_exact_boundary_max(self):
+        ca = CharacterAsset(asset_key="bot", track_values={"health": 5})
+        result = ca.adjust_track("health", +1, 0, 5)
+        assert result == 5
+
+
+class TestToggleCondition:
+    def test_toggle_on(self):
+        ca = CharacterAsset(asset_key="starship")
+        result = ca.toggle_condition("battered")
+        assert result is True
+        assert "battered" in ca.conditions
+
+    def test_toggle_off(self):
+        ca = CharacterAsset(asset_key="starship", conditions={"battered"})
+        result = ca.toggle_condition("battered")
+        assert result is False
+        assert "battered" not in ca.conditions
+
+    def test_toggle_on_then_off(self):
+        ca = CharacterAsset(asset_key="starship")
+        ca.toggle_condition("cursed")
+        ca.toggle_condition("cursed")
+        assert "cursed" not in ca.conditions
+
+    def test_condition_stored_lowercase(self):
+        ca = CharacterAsset(asset_key="starship")
+        ca.toggle_condition("BATTERED")
+        assert "battered" in ca.conditions
+
+    def test_multiple_conditions(self):
+        ca = CharacterAsset(asset_key="starship")
+        ca.toggle_condition("battered")
+        ca.toggle_condition("cursed")
+        assert "battered" in ca.conditions
+        assert "cursed" in ca.conditions
+
+
+class TestSerialisationRoundTrip:
+    def test_to_dict_includes_conditions(self):
+        ca = CharacterAsset(
+            asset_key="starship",
+            track_values={"integrity": 3},
+            conditions={"battered"},
+        )
+        data = ca.to_dict()
+        assert data["conditions"] == ["battered"]  # sorted list
+
+    def test_to_dict_conditions_sorted(self):
+        ca = CharacterAsset(asset_key="starship", conditions={"cursed", "battered"})
+        data = ca.to_dict()
+        assert data["conditions"] == ["battered", "cursed"]
+
+    def test_round_trip_with_conditions(self):
+        ca = CharacterAsset(
+            asset_key="starship",
+            abilities_unlocked=[True, False, False],
+            track_values={"integrity": 3},
+            input_values={"name": "Rust Runner"},
+            conditions={"battered"},
+        )
+        data = ca.to_dict()
+        restored = CharacterAsset.from_dict(data)
+        assert restored.asset_key == "starship"
+        assert restored.abilities_unlocked == [True, False, False]
+        assert restored.track_values == {"integrity": 3}
+        assert restored.input_values == {"name": "Rust Runner"}
+        assert restored.conditions == {"battered"}
+
+    def test_from_dict_missing_conditions_defaults_to_empty(self):
+        """Old saves without 'conditions' key load cleanly."""
+        old_data = {
+            "asset_key": "starship",
+            "abilities_unlocked": [True, False, False],
+            "track_values": {"integrity": 5},
+            "input_values": {},
+        }
+        ca = CharacterAsset.from_dict(old_data)
+        assert ca.conditions == set()
+
+    def test_from_dict_string_format(self):
+        """Old saves with assets as bare strings load cleanly."""
+        ca = CharacterAsset.from_dict("navigator")
+        assert ca.asset_key == "navigator"
+        assert ca.conditions == set()
+        assert ca.track_values == {}

--- a/tests/test_asset_commands.py
+++ b/tests/test_asset_commands.py
@@ -1,0 +1,192 @@
+"""Tests for the /asset command handler (meter and condition mutations)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from soloquest.commands.asset import handle_asset
+from soloquest.models.asset import Asset, AssetAbility, CharacterAsset
+from soloquest.models.character import Character, Stats
+from soloquest.models.session import EntryKind, Session
+
+
+def _make_state(char_assets: list[CharacterAsset], asset_defs: dict[str, Asset]) -> MagicMock:
+    state = MagicMock()
+    state.character = Character(name="Tester", stats=Stats())
+    state.character.assets = char_assets
+    state.assets = asset_defs
+    state.session = Session(number=1)
+    return state
+
+
+def _starship_def() -> Asset:
+    return Asset(
+        key="starship",
+        name="Starship",
+        category="command_vehicle",
+        tracks={"integrity": (0, 5)},
+        abilities=[AssetAbility(text="Ability one")],
+    )
+
+
+def _bot_def() -> Asset:
+    return Asset(
+        key="combat_bot",
+        name="Combat Bot",
+        category="companion",
+        tracks={"health": (0, 5)},
+    )
+
+
+def _no_track_def() -> Asset:
+    return Asset(
+        key="navigator",
+        name="Navigator",
+        category="path",
+        tracks={},
+    )
+
+
+class TestUpdatePrimaryMeter:
+    def test_decrement_primary_meter(self):
+        char_asset = CharacterAsset(asset_key="starship", track_values={"integrity": 5})
+        state = _make_state([char_asset], {"starship": _starship_def()})
+
+        handle_asset(state, ["starship", "-1"], set())
+
+        assert char_asset.track_values["integrity"] == 4
+
+    def test_increment_primary_meter(self):
+        char_asset = CharacterAsset(asset_key="starship", track_values={"integrity": 3})
+        state = _make_state([char_asset], {"starship": _starship_def()})
+
+        handle_asset(state, ["starship", "+2"], set())
+
+        assert char_asset.track_values["integrity"] == 5
+
+    def test_clamped_at_min(self):
+        char_asset = CharacterAsset(asset_key="starship", track_values={"integrity": 1})
+        state = _make_state([char_asset], {"starship": _starship_def()})
+
+        handle_asset(state, ["starship", "-10"], set())
+
+        assert char_asset.track_values["integrity"] == 0
+
+    def test_change_logged_to_session(self):
+        char_asset = CharacterAsset(asset_key="starship", track_values={"integrity": 5})
+        state = _make_state([char_asset], {"starship": _starship_def()})
+
+        handle_asset(state, ["starship", "-1"], set())
+
+        mech_entries = [
+            e for e in state.session.entries if e.kind == EntryKind.MECHANICAL
+        ]
+        assert len(mech_entries) == 1
+        assert "Integrity" in mech_entries[0].text
+        assert "Starship" in mech_entries[0].text
+
+
+class TestUpdateNamedMeter:
+    def test_update_named_meter(self):
+        char_asset = CharacterAsset(asset_key="starship", track_values={"integrity": 5})
+        state = _make_state([char_asset], {"starship": _starship_def()})
+
+        handle_asset(state, ["starship", "integrity", "-1"], set())
+
+        assert char_asset.track_values["integrity"] == 4
+
+    def test_named_meter_logged(self):
+        char_asset = CharacterAsset(asset_key="starship", track_values={"integrity": 5})
+        state = _make_state([char_asset], {"starship": _starship_def()})
+
+        handle_asset(state, ["starship", "integrity", "-2"], set())
+
+        mech_entries = [e for e in state.session.entries if e.kind == EntryKind.MECHANICAL]
+        assert len(mech_entries) == 1
+
+    @patch("soloquest.commands.asset.display.error")
+    def test_invalid_meter_name_shows_error(self, mock_error):
+        char_asset = CharacterAsset(asset_key="starship", track_values={"integrity": 5})
+        state = _make_state([char_asset], {"starship": _starship_def()})
+
+        handle_asset(state, ["starship", "shields", "-1"], set())
+
+        mock_error.assert_called_once()
+        assert char_asset.track_values.get("shields") is None
+
+
+class TestToggleCondition:
+    def test_toggle_condition_on(self):
+        char_asset = CharacterAsset(asset_key="starship", track_values={"integrity": 5})
+        state = _make_state([char_asset], {"starship": _starship_def()})
+
+        handle_asset(state, ["starship", "battered"], set())
+
+        assert "battered" in char_asset.conditions
+
+    def test_toggle_condition_off(self):
+        char_asset = CharacterAsset(
+            asset_key="starship",
+            track_values={"integrity": 5},
+            conditions={"battered"},
+        )
+        state = _make_state([char_asset], {"starship": _starship_def()})
+
+        handle_asset(state, ["starship", "battered"], set())
+
+        assert "battered" not in char_asset.conditions
+
+    def test_condition_logged_to_session(self):
+        char_asset = CharacterAsset(asset_key="starship", track_values={"integrity": 5})
+        state = _make_state([char_asset], {"starship": _starship_def()})
+
+        handle_asset(state, ["starship", "battered"], set())
+
+        mech_entries = [e for e in state.session.entries if e.kind == EntryKind.MECHANICAL]
+        assert len(mech_entries) == 1
+        assert "Battered" in mech_entries[0].text
+
+
+class TestErrorCases:
+    @patch("soloquest.commands.asset.display.error")
+    def test_unknown_asset_shows_error(self, mock_error):
+        char_asset = CharacterAsset(asset_key="starship", track_values={"integrity": 5})
+        state = _make_state([char_asset], {"starship": _starship_def()})
+
+        handle_asset(state, ["xyzunknown", "-1"], set())
+
+        mock_error.assert_called()
+
+    @patch("soloquest.commands.asset.display.error")
+    def test_asset_with_no_meter_errors(self, mock_error):
+        char_asset = CharacterAsset(asset_key="navigator")
+        state = _make_state([char_asset], {"navigator": _no_track_def()})
+
+        handle_asset(state, ["navigator", "-1"], set())
+
+        mock_error.assert_called_once()
+        assert "no condition meters" in mock_error.call_args[0][0].lower()
+
+    @patch("soloquest.commands.asset.display.error")
+    def test_mutation_on_unowned_asset_errors(self, mock_error):
+        char_asset = CharacterAsset(asset_key="starship", track_values={"integrity": 5})
+        state = _make_state(
+            [char_asset],
+            {"starship": _starship_def(), "combat_bot": _bot_def()},
+        )
+
+        # Character doesn't own combat_bot
+        handle_asset(state, ["combat_bot", "-1"], set())
+
+        mock_error.assert_called()
+
+
+class TestNoArgs:
+    @patch("soloquest.commands.asset.display.console")
+    def test_no_args_lists_assets(self, mock_console):
+        state = _make_state([], {"starship": _starship_def()})
+
+        handle_asset(state, [], set())
+
+        # Should call console.print (listing assets)
+        mock_console.print.assert_called()

--- a/tests/test_asset_display.py
+++ b/tests/test_asset_display.py
@@ -156,15 +156,20 @@ class TestAssetCommandIntegration:
             handle_asset(mock_state, args=[], _flags=set())
             # Should not raise exception
 
+    def _make_state_no_assets(self, catalog: dict) -> MagicMock:
+        """Return a mock state with an empty-asset character."""
+        mock_state = MagicMock()
+        mock_state.assets = catalog
+        mock_state.character = MagicMock()
+        mock_state.character.assets = []
+        return mock_state
+
     def test_handle_asset_with_exact_match(self):
         """Calling /asset starship should display starship details."""
-        from soloquest.loop import GameState
-
         if "starship" not in self.assets:
             return  # Skip if asset not available
 
-        mock_state = MagicMock(spec=GameState)
-        mock_state.assets = self.assets
+        mock_state = self._make_state_no_assets(self.assets)
 
         with patch("soloquest.commands.asset._display_asset_details") as mock_display:
             handle_asset(mock_state, args=["starship"], _flags=set())
@@ -176,10 +181,7 @@ class TestAssetCommandIntegration:
 
     def test_handle_asset_with_nonexistent_asset(self):
         """Calling /asset with non-existent asset should show error."""
-        from soloquest.loop import GameState
-
-        mock_state = MagicMock(spec=GameState)
-        mock_state.assets = self.assets
+        mock_state = self._make_state_no_assets(self.assets)
 
         with patch("soloquest.commands.asset.display.error") as mock_error:
             handle_asset(mock_state, args=["nonexistent_asset_xyz"], _flags=set())
@@ -191,13 +193,9 @@ class TestAssetCommandIntegration:
 
     def test_handle_asset_with_multiple_matches(self):
         """Calling /asset with ambiguous name should show warning."""
-        from soloquest.loop import GameState
-
-        mock_state = MagicMock(spec=GameState)
-        mock_state.assets = self.assets
+        mock_state = self._make_state_no_assets(self.assets)
 
         # Find a query that matches multiple assets
-        # "engine" might match "engine_upgrade" and other engine-related assets
         with patch("soloquest.commands.asset.display.warn"):
             handle_asset(mock_state, args=["module"], _flags=set())
 

--- a/uv.lock
+++ b/uv.lock
@@ -579,7 +579,7 @@ wheels = [
 
 [[package]]
 name = "soloquest"
-version = "2.3.0"
+version = "2.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "prompt-toolkit" },


### PR DESCRIPTION
## Summary

- Add `conditions: set[str]` to `CharacterAsset` with `to_dict`/`from_dict` (backward-compatible with old saves)
- Add `adjust_track()` and `toggle_condition()` helpers with clamped arithmetic
- Initialise asset track values to max at character creation via `_init_asset_tracks()`
- Extend `/asset` command to support meter adjustments and condition toggles:
  - `/asset starship -1` — decrement primary meter
  - `/asset starship integrity -1` — explicit meter name
  - `/asset starship battered` — toggle condition on/off
  - `/asset starship` — show live meter + conditions (owned assets)
- Character sheet now shows per-asset rows with meter bars and active conditions
- All changes autosaved and logged as MECHANICAL session entries

## Test plan

- [ ] `just check` passes (format + lint + 565 tests)
- [ ] New character creation → `/char` shows meter bars under each asset with a track
- [ ] `/asset starship -1` → Integrity drops, logged to session
- [ ] `/asset starship battered` → condition toggled on
- [ ] `/asset starship battered` again → condition cleared
- [ ] `/asset starship` → shows current Integrity and any active conditions
- [ ] Load an old save (no `conditions` key) → no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)