### PR TITLE
feat: style prompt with blue left-bar indicator

### DIFF
--- a/soloquest/commands/guided_mode.py
+++ b/soloquest/commands/guided_mode.py
@@ -86,7 +86,9 @@ def get_guided_prompt_html(state: GameState) -> HTML:
     phase_display = state.guided_phase.upper()
 
     # Use HTML() which prompt_toolkit will render with proper styling
-    return HTML(f"<{color}>[{phase_display}]</{color}> > ")
+    return HTML(
+        f"<ansibrightblue>▌</ansibrightblue>\n<ansibrightblue>▌</ansibrightblue> <{color}>[{phase_display}]</{color}> "
+    )
 
 
 def advance_phase(state: GameState) -> None:

--- a/soloquest/loop.py
+++ b/soloquest/loop.py
@@ -225,7 +225,13 @@ def run_session(
                 prompt_text = get_guided_prompt_html(state)
                 line = prompt_session.prompt(prompt_text)
             else:
-                line = prompt_session.prompt("> ")
+                from prompt_toolkit.formatted_text import HTML
+
+                line = prompt_session.prompt(
+                    HTML(
+                        "<ansibrightblue>▌</ansibrightblue>\n<ansibrightblue>▌</ansibrightblue> "
+                    )
+                )
         except (KeyboardInterrupt, EOFError):
             display.console.print()
             _handle_interrupt(state)


### PR DESCRIPTION
## Summary

- Prompt is now two lines: a blank `▌` line above, then `▌ ` on the input line
- Gives the input area visual separation from game output without a `>` glyph
- Guided mode gets the same treatment, keeping the phase label on the input line

## Test plan

- [ ] `just check` passes
- [ ] Launch game, prompt shows two-line blue bar style
- [ ] `/guide start` — guided mode prompt shows bar + phase label

🤖 Generated with [Claude Code](https://claude.com/claude-code)