### PR TITLE
chore: add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+## Summary
+
+-
+-
+
+## Test plan
+
+- [ ] `just check` passes (lint + tests)
+- [ ] Coverage hasn't dropped
+- [ ] Manually tested the change


### PR DESCRIPTION
## Summary

- Adds `.github/pull_request_template.md` to pre-populate new PRs
- Template enforces conventions from CLAUDE.md: Summary bullets and Test plan checklist
- Keeps PR authors aligned on Conventional Commits title format

## Test plan

- [ ] Open a new PR and confirm the template appears automatically