### PR TITLE
refactor: replace global config state with singleton Config class

### DIFF
--- a/soloquest/commands/character.py
+++ b/soloquest/commands/character.py
@@ -95,9 +95,9 @@ def handle_momentum(state: GameState, args: list[str], flags: set[str]) -> None:
 
 def handle_settings(state: GameState, args: list[str], flags: set[str]) -> None:
     if not args:
-        from soloquest.config import get_adventures_dir
+        from soloquest.config import config
 
-        display.info(f"  Adventures directory: {get_adventures_dir()}")
+        display.info(f"  Adventures directory: {config.adventures_dir}")
         display.info(f"  Dice mode: {state.dice_mode.value}")
         display.info("  Usage: /settings dice [digital|physical|mixed]")
         return

--- a/soloquest/config.py
+++ b/soloquest/config.py
@@ -5,71 +5,59 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
-# Configuration directory follows XDG Base Directory spec
 CONFIG_DIR = Path.home() / ".config" / "soloquest"
 CONFIG_FILE = CONFIG_DIR / "config.toml"
 
-# Global state for CLI-provided adventures directory
-_cli_adventures_dir: Path | None = None
 
+class Config:
+    """Shared configuration object.
 
-def set_adventures_dir(path: Path | str | None) -> None:
-    """
-    Set the adventures directory from CLI argument.
-
-    Args:
-        path: Path to adventures directory, or None to clear
-    """
-    global _cli_adventures_dir
-    _cli_adventures_dir = None if path is None else Path(path).expanduser().resolve()
-
-
-def get_adventures_dir() -> Path:
-    """
-    Get the adventures directory path.
-
-    Priority order:
-    1. Command-line argument (--adventures-dir)
+    Priority order for adventures_dir:
+    1. CLI argument (set via set_adventures_dir())
     2. SOLOQUEST_ADVENTURES_DIR environment variable
     3. Config file setting (future)
     4. Default: ~/soloquest-adventures
-
-    The adventures directory contains:
-    - saves/      Character save files
-    - sessions/   Individual session markdown
-    - journal/    Cumulative journal markdown
     """
-    # 1. Check CLI argument
-    if _cli_adventures_dir is not None:
-        return _cli_adventures_dir
 
-    # 2. Check environment variable
-    env_path = os.environ.get("SOLOQUEST_ADVENTURES_DIR")
-    if env_path:
-        return Path(env_path).expanduser().resolve()
+    _instance: Config | None = None
+    _adventures_dir: Path | None = None
 
-    # 3. Check config file (if we add TOML support later)
-    # if CONFIG_FILE.exists():
-    #     import tomllib
-    #     config = tomllib.loads(CONFIG_FILE.read_text())
-    #     if "adventures_dir" in config:
-    #         return Path(config["adventures_dir"]).expanduser().resolve()
+    def __new__(cls) -> Config:
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
 
-    # 4. Default to ~/soloquest-adventures
-    return Path.home() / "soloquest-adventures"
+    @property
+    def adventures_dir(self) -> Path:
+        """Get the adventures directory path."""
+        if self._adventures_dir is not None:
+            return self._adventures_dir
+
+        env_path = os.environ.get("SOLOQUEST_ADVENTURES_DIR")
+        if env_path:
+            return Path(env_path).expanduser().resolve()
+
+        return Path.home() / "soloquest-adventures"
+
+    def set_adventures_dir(self, path: Path | str | None) -> None:
+        """Set the adventures directory from CLI argument."""
+        self._adventures_dir = None if path is None else Path(path).expanduser().resolve()
+
+    def saves_dir(self) -> Path:
+        """Get the saves directory path."""
+        return self.adventures_dir / "saves"
+
+    def sessions_dir(self) -> Path:
+        """Get the sessions directory path."""
+        return self.adventures_dir / "sessions"
+
+    def journal_dir(self) -> Path:
+        """Get the journal directory path."""
+        return self.adventures_dir / "journal"
+
+    def reset(self) -> None:
+        """Reset config to defaults (useful for testing)."""
+        self._adventures_dir = None
 
 
-# Convenience accessors for common paths
-def saves_dir() -> Path:
-    """Get the saves directory path."""
-    return get_adventures_dir() / "saves"
-
-
-def sessions_dir() -> Path:
-    """Get the sessions directory path."""
-    return get_adventures_dir() / "sessions"
-
-
-def journal_dir() -> Path:
-    """Get the journal directory path."""
-    return get_adventures_dir() / "journal"
+config = Config()

--- a/soloquest/journal/exporter.py
+++ b/soloquest/journal/exporter.py
@@ -9,18 +9,18 @@ if TYPE_CHECKING:
     from soloquest.models.character import Character
     from soloquest.models.session import Session
 
-from soloquest.config import journal_dir, sessions_dir
+from soloquest.config import config
 from soloquest.models.session import EntryKind
 
 
 def _sessions_dir() -> Path:
     """Get the sessions directory path."""
-    return sessions_dir()
+    return config.sessions_dir()
 
 
 def _journal_dir() -> Path:
     """Get the journal directory path."""
-    return journal_dir()
+    return config.journal_dir()
 
 
 def _character_slug(character_name: str) -> str:

--- a/soloquest/main.py
+++ b/soloquest/main.py
@@ -61,14 +61,12 @@ def _show_resume_context(session: Session | None) -> None:
 
 
 def main() -> None:
-    from soloquest.config import set_adventures_dir
+    from soloquest.config import config
 
-    # Parse command-line arguments
     args = parse_args()
 
-    # Set adventures directory from CLI argument if provided
     if args.adventures_dir:
-        set_adventures_dir(args.adventures_dir)
+        config.set_adventures_dir(args.adventures_dir)
 
     data_dir = Path(__file__).parent / "data"
 

--- a/soloquest/state/save.py
+++ b/soloquest/state/save.py
@@ -6,7 +6,7 @@ import contextlib
 import json
 from pathlib import Path
 
-from soloquest.config import saves_dir
+from soloquest.config import config
 from soloquest.engine.dice import DiceMode
 from soloquest.models.character import Character
 from soloquest.models.session import Session
@@ -15,7 +15,7 @@ from soloquest.models.vow import Vow
 
 def _saves_dir() -> Path:
     """Get the saves directory path."""
-    return saves_dir()
+    return config.saves_dir()
 
 
 def saves_path(character_name: str) -> Path:


### PR DESCRIPTION
## Summary
- Replaces mutable global `_cli_adventures_dir` variable with a singleton `Config` class
- Provides cleaner API with properties for `adventures_dir`, and methods for `saves_dir()`, `sessions_dir()`, `journal_dir()`
- Added `reset()` method for testing isolation
- Updated all consumers (`main.py`, `character.py`, `exporter.py`, `save.py`) to use the config object

## Test plan
- [x] All 597 tests pass
- [x] Ruff linting passes
- [x] Manual testing of CLI startup with default and custom adventures directories