### PR TITLE
fix: implement Ask the Oracle with d100 odds mechanic

### DIFF
--- a/soloquest/data/moves.toml
+++ b/soloquest/data/moves.toml
@@ -177,7 +177,7 @@ oracle_table = "pay_the_price"
 [ask_the_oracle]
 name = "Ask the Oracle"
 category = "fate"
-description = "When you seek to resolve questions, discover details in the world, determine how an NPC acts or responds, or trigger a discovery, you may roll the challenge dice and interpret the results. Use the Action and Theme oracles for open-ended questions."
+description = "When you seek to resolve questions, discover details in the world, determine how an NPC acts or responds, or trigger a discovery, choose the odds and roll your oracle die (d100). On a result within the range, the answer is **yes**. Otherwise, it is **no**. For open-ended answers, use the Action and Theme oracles."
 stat_options = []
 oracle_roll = true
 

--- a/tests/test_move_commands.py
+++ b/tests/test_move_commands.py
@@ -377,18 +377,23 @@ class TestHandleMoveOracleRoll:
         }
         self.state.dice = MagicMock()
 
-    @patch("soloquest.commands.move.roll_challenge_dice")
+    @patch("soloquest.commands.move.roll_oracle")
+    @patch("soloquest.commands.move.Prompt.ask", return_value="3")
+    @patch("soloquest.commands.move.display.console")
     @patch("soloquest.commands.move.display.info")
-    def test_handle_ask_the_oracle_rolls_challenge_dice(self, mock_info, mock_roll):
-        """Ask the Oracle should roll challenge dice."""
-        mock_roll.return_value = (7, 4)
+    def test_handle_ask_the_oracle_rolls_d100(
+        self, mock_info, mock_console, mock_prompt, mock_roll
+    ):
+        """Ask the Oracle should roll d100 against chosen odds."""
+        mock_roll.return_value = 42
 
         handle_move(self.state, ["ask_the_oracle"], set())
 
         mock_roll.assert_called_once_with(self.state.dice)
-        # Should display the result
-        info_calls = [call[0][0] for call in mock_info.call_args_list]
-        assert any("Challenge dice" in call for call in info_calls)
+        # Should log result to session
+        entries = " ".join(e.text for e in self.state.session.entries)
+        assert "Ask the Oracle" in entries
+        assert "42" in entries
 
 
 class TestHandleMoveForsakeVow:


### PR DESCRIPTION
## Summary

- Replace incorrect challenge-dice roll with proper d100 yes/no oracle (per rulebook p.64)
- Display move description and odds table together inside the cyan panel, matching other moves
- Prompt player to choose likelihood (Almost Certain 90, Likely 75, 50/50 50, Unlikely 25, Small Chance 10), roll d100, and show Yes/No result with colour
- Correct the move description in `moves.toml` (previously said "challenge dice")
- Update test to verify d100 is rolled and result is logged to session

## Test plan

- [x] `/move ask_the_oracle` shows description + odds table inside the panel box
- [x] Selecting an odds level rolls d100 and prints a green Yes or red No with the roll value
- [x] Cancelling the dice roll exits cleanly
- [x] Invalid odds selection shows an error
- [x] Result is logged to the session mechanical log
- [x] All 597 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)