### PR TITLE
feat: list all oracles on bare /oracle, add --table view for physical play

### DIFF
--- a/soloquest/commands/oracle.py
+++ b/soloquest/commands/oracle.py
@@ -12,10 +12,121 @@ if TYPE_CHECKING:
     from soloquest.loop import GameState
 
 
+_ORACLE_CATEGORIES: list[tuple[str, list[str]]] = [
+    ("Core", ["action", "theme", "descriptor", "focus"]),
+    (
+        "Characters",
+        [
+            "given_name",
+            "family_name",
+            "callsign",
+            "role",
+            "goal",
+            "quirks",
+            "disposition",
+            "backstory_prompts",
+            "identity",
+        ],
+    ),
+    ("NPCs", ["npc_role", "npc_disposition", "encountered_behavior", "initial_contact"]),
+    ("Places", ["location", "settlement", "settlement_name", "environment"]),
+    (
+        "Space",
+        ["space", "deep_space", "expanse", "terminus", "outlands", "planetside", "stellar_object"],
+    ),
+    ("Planets", ["planet_class", "first_look", "inner_first_look", "outer_first_look", "orbital"]),
+    ("Starships", ["starship", "starship_history", "starship_quirks", "fleet", "class"]),
+    (
+        "Factions",
+        [
+            "affiliation",
+            "authority",
+            "dominion",
+            "fringe_group",
+            "guild",
+            "influence",
+            "leadership",
+            "legacy",
+            "projects",
+            "rumors",
+            "trouble",
+        ],
+    ),
+    (
+        "Events",
+        [
+            "begin_a_session",
+            "inciting_incident",
+            "combat_action",
+            "combat_event",
+            "peril",
+            "opportunity",
+            "story_clue",
+            "story_complication",
+            "make_a_discovery",
+            "confront_chaos",
+            "sector_trouble",
+        ],
+    ),
+    ("Yes / No", ["almost_certain", "likely", "fifty_fifty", "unlikely", "small_chance"]),
+]
+
+_ORACLE_INSPIRATIONS: list[tuple[str, str]] = [
+    ("Start a new session", "/oracle begin_a_session"),
+    ("Quick spark of inspiration", "/oracle action theme"),
+    ("Describe a location", "/oracle descriptor location"),
+    ("Create an NPC", "/oracle given_name role goal disposition quirks"),
+    ("Name a settlement", "/oracle settlement_name settlement"),
+    ("Meet trouble", "/oracle inciting_incident"),
+    ("Discover something unexpected", "/oracle make_a_discovery"),
+]
+
+
+def _show_oracle_list(state: GameState) -> None:
+    from rich.console import Group
+    from rich.panel import Panel
+    from rich.table import Table
+    from rich.text import Text
+
+    # Build the grouped oracle table
+    grid = Table.grid(padding=(0, 2))
+    grid.add_column(style="bold cyan", no_wrap=True)  # category
+    grid.add_column(style="dim")  # keys
+
+    for category, keys in _ORACLE_CATEGORIES:
+        # Only show keys that actually exist in the loaded tables
+        available = [k for k in keys if k in state.oracles]
+        if available:
+            grid.add_row(category, "  ".join(available))
+
+    # Build inspiration examples
+    examples = Text("\nInspiration combos:\n", style="bold")
+    for label, cmd in _ORACLE_INSPIRATIONS:
+        examples.append(f"  {label:<32}", style="dim")
+        examples.append(f"{cmd}\n", style="cyan")
+
+    display.console.print(
+        Panel(
+            Group(grid, examples),
+            title="[bold]Oracle Tables[/bold]",
+            subtitle="[dim]/oracle [table] [table...][/dim]",
+            border_style="cyan",
+        )
+    )
+
+
 def handle_oracle(state: GameState, args: list[str], flags: set[str]) -> None:
     if not args:
-        display.error("Usage: /oracle [table]  (e.g. /oracle action theme)")
-        display.info("Try /help oracles to see available tables.")
+        _show_oracle_list(state)
+        return
+
+    if "table" in flags:
+        for query in args:
+            matches = fuzzy_match_oracle(query, state.oracles)
+            if not matches:
+                display.warn(f"Oracle table not found: '{query}'")
+                continue
+            display.oracle_table_view(matches[0])
         return
 
     # Support multiple table names followed by an optional trailing note.

--- a/soloquest/commands/registry.py
+++ b/soloquest/commands/registry.py
@@ -95,7 +95,7 @@ COMMAND_HELP: dict[str, str] = {
     "truths": "/truths [start|show] — choose campaign truths or view current truths",
     "next": "/next — advance to next phase (guided mode only)",
     "move": "/move [name] (alias: /m) — resolve a move (e.g. /move strike)",
-    "oracle": "/oracle [table] (alias: /o) — consult an oracle (e.g. /oracle action theme)",
+    "oracle": "/oracle [table] (alias: /o) — consult an oracle (e.g. /oracle action theme)  --table to view full table",
     "asset": "/asset [name] [+/-N | meter +/-N | condition] — view or update asset meters/conditions",
     "vow": "/vow [rank] [text] (alias: /v) — create a vow",
     "progress": "/progress [vow] (alias: /p) — mark progress on a vow",

--- a/soloquest/ui/display.py
+++ b/soloquest/ui/display.py
@@ -134,7 +134,7 @@ def move_result_panel(
 
 def oracle_result_panel(table_name: str, roll: int, result: str) -> None:
     console.print(
-        f"  [bright_cyan]└[/bright_cyan]  [dim]{table_name.upper()}[/dim]"
+        f"  [bright_cyan]└[/bright_cyan]  🔮 [dim]{table_name.upper()}[/dim]"
         f"  [dim]{roll}[/dim]  [dim]→[/dim]  [bold cyan]{result}[/bold cyan]"
     )
 
@@ -145,9 +145,32 @@ def oracle_result_panel_combined(results: list) -> None:
     for r in results:
         padded_name = r.table_name.upper().ljust(max_name_width)
         console.print(
-            f"  [bright_cyan]└[/bright_cyan]  [dim]{padded_name}[/dim]"
+            f"  [bright_cyan]└[/bright_cyan]  🔮 [dim]{padded_name}[/dim]"
             f"  [dim]{r.roll:3d}[/dim]  [dim]→[/dim]  [bold cyan]{r.result}[/bold cyan]"
         )
+
+
+def oracle_table_view(table: object) -> None:
+    """Display the full contents of an oracle table for physical dice reference."""
+    from soloquest.engine.oracles import OracleTable
+
+    assert isinstance(table, OracleTable)
+    t = Table(show_header=True, header_style="bold", box=None, padding=(0, 1))
+    t.add_column("Roll", style="dim", justify="right", no_wrap=True)
+    t.add_column("Result", style="bold cyan")
+
+    for low, high, text in table.results:
+        roll_range = str(low) if low == high else f"{low}–{high}"
+        t.add_row(roll_range, text)
+
+    console.print(
+        Panel(
+            t,
+            title=f"[bold]🔮 {table.name}[/bold]",
+            subtitle=f"[dim]{table.die}[/dim]",
+            border_style="cyan",
+        )
+    )
 
 
 def character_sheet(

--- a/tests/test_oracle_display.py
+++ b/tests/test_oracle_display.py
@@ -102,21 +102,19 @@ class TestOracleCommand:
     def setup_method(self):
         self.oracles = load_oracles(DATA_DIR)
 
-    def test_oracle_with_no_args_shows_error(self):
-        """Calling /oracle with no args should show usage error."""
+    def test_oracle_with_no_args_shows_list(self):
+        """Calling /oracle with no args should show the oracle table list."""
         from soloquest.loop import GameState
 
         mock_state = MagicMock(spec=GameState)
         mock_state.oracles = self.oracles
         mock_state.dice = MagicMock()
 
-        with patch("soloquest.commands.oracle.display.error") as mock_error:
+        with patch("soloquest.commands.oracle.display.console") as mock_console:
             handle_oracle(mock_state, args=[], flags=set())
 
-            # Should have shown error
-            mock_error.assert_called_once()
-            error_msg = mock_error.call_args[0][0]
-            assert "Usage" in error_msg or "oracle" in error_msg.lower()
+            # Should have printed the oracle list panel
+            mock_console.print.assert_called_once()
 
     def test_oracle_with_single_table(self):
         """Calling /oracle action should roll on action table."""


### PR DESCRIPTION
## Summary

- `/oracle` with no args now shows a panel of all tables grouped by category (Core, Characters, NPCs, Places, Space, Planets, Starships, Factions, Events, Yes/No) with inspiration combos at the bottom
- `/oracle <table> --table` renders the full roll→result table in a cyan panel for use as a physical dice reference; supports multiple tables and fuzzy matching (e.g. `/oracle action theme --table`)
- Oracle results now prefixed with 🔮 to match 🎲 on dice rolls
- NPC inspiration combo expanded to include `disposition` and `quirks`

## Test plan

- [ ] `/oracle` with no args shows grouped table list with inspiration examples
- [ ] `/oracle action --table` renders full Action oracle as a reference table
- [ ] `/oracle action theme --table` renders both tables in sequence
- [ ] `/oracle unknown --table` shows a warning for unrecognised tables
- [ ] `/oracle action theme` still rolls as before (flag doesn't affect normal rolls)
- [ ] Oracle roll output shows 🔮 prefix
- [ ] All 597 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)