### PR TITLE
feat: sandbox startup mode and /campaign start wizard

### DIFF
--- a/soloquest/commands/new_character.py
+++ b/soloquest/commands/new_character.py
@@ -244,14 +244,19 @@ def _prompt_stats() -> Stats | None:
 def run_new_character_flow(
     data_dir: Path,
     truth_categories: dict,
+    include_truths: bool = True,
 ) -> tuple[Character, list[Vow], DiceMode] | None:
-    """Run the full new-game flow: Truths → character wizard.
+    """Run the full new-game flow: (optionally Truths →) character wizard.
 
     Returns (character, vows, dice_mode) or None if cancelled.
+    Set include_truths=False for co-op joiners who skip world setup.
     """
-    truths = run_truths_wizard(truth_categories)
-    if truths is None:
-        return None  # cancelled during truths
+    if include_truths:
+        truths = run_truths_wizard(truth_categories)
+        if truths is None:
+            return None  # cancelled during truths
+    else:
+        truths = []
 
     result = run_creation_wizard(data_dir)
     if result is None:

--- a/soloquest/commands/registry.py
+++ b/soloquest/commands/registry.py
@@ -92,7 +92,7 @@ def fuzzy_match_command(name: str, known: list[str]) -> str | None:
 
 
 COMMAND_HELP: dict[str, str] = {
-    "campaign": "/campaign [create|join|status|leave] — manage co-op campaigns",
+    "campaign": "/campaign [start|create|join|status|leave] — manage campaigns (/campaign start to begin)",
     "guide": "/guide [step|start|stop] — show gameplay loop or enter guided mode (try: /guide start)",
     "truths": "/truths [start|show] — choose campaign truths or view current truths",
     "next": "/next — advance to next phase (guided mode only)",

--- a/soloquest/state/campaign.py
+++ b/soloquest/state/campaign.py
@@ -121,11 +121,11 @@ def join_campaign(campaign_dir: Path, player_id: str) -> CampaignState:
     """Add a player to an existing campaign.
 
     Returns the updated CampaignState.
-    Raises ValueError if player is already a member.
+    Idempotent: if player is already a member, returns the campaign as-is.
     """
     campaign = load_campaign(campaign_dir)
     if player_id in campaign.players:
-        raise ValueError(f"'{player_id}' is already a member of '{campaign.name}'")
+        return campaign
     campaign.players[player_id] = PlayerInfo(joined=datetime.now(UTC).isoformat())
     save_campaign(campaign, campaign_dir)
     return campaign

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -1,0 +1,129 @@
+"""Tests for startup logic — sandbox mode and auto-resume."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+
+class TestSandboxStartup:
+    def test_sandbox_creates_wanderer_character(self):
+        """No saves → sandbox creates Character('Wanderer')."""
+        from soloquest.main import main
+
+        with (
+            patch("soloquest.main.list_saves", return_value=[]),
+            patch("soloquest.main.parse_args") as mock_args,
+            patch("soloquest.main.display"),
+            patch("soloquest.loop.run_session") as mock_run,
+        ):
+            mock_args.return_value = MagicMock(new=False, adventures_dir=None)
+            main()
+
+        mock_run.assert_called_once()
+        character = mock_run.call_args[0][0]
+        assert character.name == "Wanderer"
+
+    def test_sandbox_does_not_call_new_character_flow(self):
+        """No saves → sandbox does NOT call run_new_character_flow."""
+        from soloquest.main import main
+
+        with (
+            patch("soloquest.main.list_saves", return_value=[]),
+            patch("soloquest.main.parse_args") as mock_args,
+            patch("soloquest.main.display"),
+            patch("soloquest.loop.run_session"),
+            patch("soloquest.commands.new_character.run_new_character_flow") as mock_flow,
+        ):
+            mock_args.return_value = MagicMock(new=False, adventures_dir=None)
+            main()
+
+        mock_flow.assert_not_called()
+
+    def test_new_flag_triggers_sandbox(self):
+        """--new flag → sandbox mode even when saves exist."""
+        from soloquest.main import main
+
+        with (
+            patch("soloquest.main.list_saves", return_value=["Kira"]),
+            patch("soloquest.main.parse_args") as mock_args,
+            patch("soloquest.main.display"),
+            patch("soloquest.loop.run_session") as mock_run,
+        ):
+            mock_args.return_value = MagicMock(new=True, adventures_dir=None)
+            main()
+
+        character = mock_run.call_args[0][0]
+        assert character.name == "Wanderer"
+
+    def test_sandbox_passes_empty_vows(self):
+        """Sandbox mode starts with empty vows list."""
+        from soloquest.main import main
+
+        with (
+            patch("soloquest.main.list_saves", return_value=[]),
+            patch("soloquest.main.parse_args") as mock_args,
+            patch("soloquest.main.display"),
+            patch("soloquest.loop.run_session") as mock_run,
+        ):
+            mock_args.return_value = MagicMock(new=False, adventures_dir=None)
+            main()
+
+        vows = mock_run.call_args[0][1]
+        assert vows == []
+
+
+class TestAutoResumeStartup:
+    def test_auto_resume_loads_most_recent(self):
+        """With saves → auto-resumes most recent (unchanged UX)."""
+        from soloquest.engine.dice import DiceMode
+        from soloquest.main import main
+        from soloquest.models.character import Character
+
+        saved_character = Character("Kira")
+
+        with (
+            patch("soloquest.main.list_saves", return_value=["Kira"]),
+            patch("soloquest.main.parse_args") as mock_args,
+            patch("soloquest.main.load_most_recent") as mock_load,
+            patch("soloquest.main.display"),
+            patch("soloquest.loop.run_session") as mock_run,
+        ):
+            mock_args.return_value = MagicMock(new=False, adventures_dir=None)
+            mock_load.return_value = (saved_character, [], 3, DiceMode.DIGITAL, None)
+            main()
+
+        character = mock_run.call_args[0][0]
+        assert character.name == "Kira"
+
+    def test_auto_resume_not_called_when_new_flag(self):
+        """--new flag → load_most_recent is NOT called."""
+        from soloquest.main import main
+
+        with (
+            patch("soloquest.main.list_saves", return_value=["Kira"]),
+            patch("soloquest.main.parse_args") as mock_args,
+            patch("soloquest.main.load_most_recent") as mock_load,
+            patch("soloquest.main.display"),
+            patch("soloquest.loop.run_session"),
+        ):
+            mock_args.return_value = MagicMock(new=True, adventures_dir=None)
+            main()
+
+        mock_load.assert_not_called()
+
+    def test_corrupted_save_returns_early(self):
+        """Corrupted save → error message, run_session not called."""
+        from soloquest.main import main
+
+        with (
+            patch("soloquest.main.list_saves", return_value=["Kira"]),
+            patch("soloquest.main.parse_args") as mock_args,
+            patch("soloquest.main.load_most_recent", return_value=None),
+            patch("soloquest.main.display") as mock_display,
+            patch("soloquest.loop.run_session") as mock_run,
+        ):
+            mock_args.return_value = MagicMock(new=False, adventures_dir=None)
+            main()
+
+        mock_run.assert_not_called()
+        mock_display.error.assert_called_once()


### PR DESCRIPTION
## Summary

- New players drop straight into the game loop on first launch with a placeholder `Wanderer` character — no forced 45-minute world-creation wizard
- `--new` flag and the no-saves path both use sandbox mode
- `/campaign start` is now the unified entry point for real campaign setup: solo adventure, create co-op, or join co-op
- Existing saves still auto-resume unchanged
- `join_campaign()` made idempotent (rejoining returns campaign as-is)
- `run_session()` accepts optional `campaign`/`campaign_dir` params and wires the correct sync adapter automatically
- `"campaign"` added to `AUTOSAVE_AFTER` so `/campaign start` persists state immediately
- `_show_no_campaign_help()` updated to mention `/campaign start`

## Test plan

- [ ] `tests/test_startup.py` (7 new tests): Wanderer character on no-saves, `--new` flag, empty vows, auto-resume path, corrupted save early exit
- [ ] `tests/test_campaign.py::TestHandleStart` (5 new tests): solo path, solo cancel, create co-op state wiring, join co-op state wiring, join skips truths
- [ ] `uv run python -m pytest` — 657 passed
- [ ] Manual: `soloquest` with no saves → splash + hint → `/oracle` works immediately
- [ ] Manual: `/campaign start` → Solo Adventure → truths + char creation → saved
- [ ] Manual: `/campaign start` → Create Co-op → campaign name + truths + char
- [ ] Manual: `/campaign start` → Join → list → pick → char only (no truths)

Closes part of #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)