### PR TITLE
feat: oracle interpretation workflow (/interpret and /accept)

### DIFF
--- a/soloquest/commands/interpret.py
+++ b/soloquest/commands/interpret.py
@@ -1,0 +1,86 @@
+"""Oracle interpretation commands — /interpret and /accept."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from soloquest.sync.models import Event
+from soloquest.ui import display
+
+if TYPE_CHECKING:
+    from soloquest.loop import GameState
+
+
+def handle_interpret(state: GameState, args: list[str], flags: set[str]) -> None:
+    """Propose an interpretation of the last oracle roll.
+
+    Usage:
+        /interpret [text]   — propose what the oracle means in fiction
+
+    In solo mode, the interpretation is logged immediately as a note.
+    In co-op mode, it is also published to the sync layer so partners can see
+    and accept it via /accept.
+    """
+    if not args:
+        display.warn("Usage: /interpret [your interpretation]")
+        return
+
+    text = " ".join(args)
+    player = state.character.name
+
+    # Log interpretation to session immediately (both solo and co-op)
+    state.session.add_note(f"[Interpretation] {text}", player=player)
+    display.console.print(
+        f"  [magenta]└[/magenta]  💬 [dim]interpretation logged:[/dim]  [italic]{text}[/italic]"
+    )
+
+    # In co-op, publish as an interpret event so partners can see it
+    if state.campaign is not None:
+        event = Event(
+            player=player,
+            type="interpret",
+            data={
+                "text": text,
+                **({"ref": state.last_oracle_event_id} if state.last_oracle_event_id else {}),
+            },
+        )
+        state.sync.publish(event)
+
+
+def handle_accept(state: GameState, args: list[str], flags: set[str]) -> None:
+    """Accept a pending partner interpretation and log it to the session.
+
+    Usage:
+        /accept             — accept the most recent partner interpretation
+
+    In solo mode this is a no-op (all interpretations are auto-accepted).
+    In co-op mode, logs the pending interpretation as a note and publishes
+    an accept_interpretation event.
+    """
+    if state.campaign is None:
+        display.info("  (Solo mode — interpretations are accepted automatically.)")
+        return
+
+    event = state.pending_partner_interpretation
+    if event is None:
+        display.info("  No pending partner interpretation. Use /sync to check for activity.")
+        return
+
+    text = event.data.get("text", "")
+    player = state.character.name
+
+    # Log the accepted interpretation to this player's session
+    state.session.add_note(f"[Interpretation accepted] {text}", player=player)
+    display.success(f"Interpretation accepted: {text}")
+
+    # Publish acceptance event
+    state.sync.publish(
+        Event(
+            player=player,
+            type="accept_interpretation",
+            data={"ref": event.id, "text": text},
+        )
+    )
+
+    # Clear the pending interpretation
+    state.pending_partner_interpretation = None

--- a/soloquest/commands/oracle.py
+++ b/soloquest/commands/oracle.py
@@ -192,15 +192,15 @@ def handle_oracle(state: GameState, args: list[str], flags: set[str]) -> None:
         )
 
     # Publish to the sync layer (no-op for LocalAdapter, written to JSONL for FileLogAdapter)
-    state.sync.publish(
-        Event(
-            player=player,
-            type="oracle_roll",
-            data={
-                "tables": [r.table_name for r in results],
-                "rolls": [r.roll for r in results],
-                "results": [r.result for r in results],
-                **({"note": note} if note else {}),
-            },
-        )
+    oracle_event = Event(
+        player=player,
+        type="oracle_roll",
+        data={
+            "tables": [r.table_name for r in results],
+            "rolls": [r.roll for r in results],
+            "results": [r.result for r in results],
+            **({"note": note} if note else {}),
+        },
     )
+    state.sync.publish(oracle_event)
+    state.last_oracle_event_id = oracle_event.id

--- a/soloquest/commands/registry.py
+++ b/soloquest/commands/registry.py
@@ -94,6 +94,8 @@ def fuzzy_match_command(name: str, known: list[str]) -> str | None:
 COMMAND_HELP: dict[str, str] = {
     "campaign": "/campaign [start|create|join|status|leave] — manage campaigns (/campaign start to begin)",
     "sync": "/sync — check for new activity from co-op partners",
+    "interpret": "/interpret [text] — propose an interpretation of the last oracle roll",
+    "accept": "/accept — accept a pending partner interpretation (co-op)",
     "guide": "/guide [step|start|stop] — show gameplay loop or enter guided mode (try: /guide start)",
     "truths": "/truths [start|show] — choose campaign truths or view current truths",
     "next": "/next — advance to next phase (guided mode only)",

--- a/soloquest/ui/display.py
+++ b/soloquest/ui/display.py
@@ -432,6 +432,12 @@ def partner_activity(events: list) -> None:
                     f"  [bright_cyan]└[/bright_cyan]  🔮 [dim]{padded}[/dim]"
                     f"  [dim]{roll:3d}[/dim]  [dim]→[/dim]  [bold cyan]{result}[/bold cyan]"
                 )
+        elif event.type == "interpret":
+            text = event.data.get("text", "")
+            console.print(
+                f"  [magenta]└[/magenta]  💬 [dim]interpretation:[/dim]  [italic]{text}[/italic]"
+            )
+            console.print("  [dim]    Type /accept to adopt this interpretation.[/dim]")
         else:
             # Generic fallback for unrecognised event types
             console.print(f"  [dim]  {event.type}: {event.data}[/dim]")

--- a/tests/test_interpret.py
+++ b/tests/test_interpret.py
@@ -1,0 +1,194 @@
+"""Tests for /interpret and /accept commands."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from soloquest.models.campaign import CampaignState
+from soloquest.models.session import EntryKind, Session
+from soloquest.sync import LocalAdapter
+from soloquest.sync.models import Event
+
+
+def _make_state(campaign=None, last_oracle_event_id=None):
+    from soloquest.loop import GameState
+
+    character = MagicMock()
+    character.name = "Kira"
+
+    state = GameState(
+        character=character,
+        vows=[],
+        session=Session(number=1),
+        session_count=0,
+        dice_mode=MagicMock(),
+        dice=MagicMock(),
+        moves={},
+        oracles={},
+        assets={},
+        truth_categories={},
+        sync=LocalAdapter("Kira"),
+        campaign=campaign,
+        last_oracle_event_id=last_oracle_event_id,
+    )
+    return state
+
+
+# ---------------------------------------------------------------------------
+# handle_interpret
+# ---------------------------------------------------------------------------
+
+
+class TestHandleInterpret:
+    def test_no_args_warns(self):
+        from soloquest.commands.interpret import handle_interpret
+
+        state = _make_state()
+        with patch("soloquest.commands.interpret.display") as mock_display:
+            handle_interpret(state, [], set())
+        mock_display.warn.assert_called_once()
+
+    def test_logs_note_to_session(self):
+        from soloquest.commands.interpret import handle_interpret
+
+        state = _make_state()
+        handle_interpret(state, ["the", "blacksmith", "arms", "rebels"], set())
+        entries = state.session.entries
+        assert len(entries) == 1
+        assert entries[0].kind == EntryKind.NOTE
+        assert "the blacksmith arms rebels" in entries[0].text
+        assert "[Interpretation]" in entries[0].text
+
+    def test_note_has_player_attribution(self):
+        from soloquest.commands.interpret import handle_interpret
+
+        state = _make_state()
+        handle_interpret(state, ["arm", "rebels"], set())
+        assert state.session.entries[0].player == "Kira"
+
+    def test_solo_does_not_publish_event(self):
+        from soloquest.commands.interpret import handle_interpret
+
+        state = _make_state(campaign=None)
+        mock_sync = MagicMock()
+        state.sync = mock_sync
+        handle_interpret(state, ["something"], set())
+        mock_sync.publish.assert_not_called()
+
+    def test_coop_publishes_interpret_event(self):
+        from soloquest.commands.interpret import handle_interpret
+
+        campaign = MagicMock(spec=CampaignState)
+        state = _make_state(campaign=campaign)
+        mock_sync = MagicMock()
+        state.sync = mock_sync
+        handle_interpret(state, ["something"], set())
+        mock_sync.publish.assert_called_once()
+        event = mock_sync.publish.call_args[0][0]
+        assert event.type == "interpret"
+        assert event.data["text"] == "something"
+
+    def test_coop_includes_oracle_ref_when_available(self):
+        from soloquest.commands.interpret import handle_interpret
+
+        campaign = MagicMock(spec=CampaignState)
+        state = _make_state(campaign=campaign, last_oracle_event_id="oracle-uuid-123")
+        mock_sync = MagicMock()
+        state.sync = mock_sync
+        handle_interpret(state, ["my", "read"], set())
+        event = mock_sync.publish.call_args[0][0]
+        assert event.data["ref"] == "oracle-uuid-123"
+
+    def test_coop_no_ref_when_no_oracle_yet(self):
+        from soloquest.commands.interpret import handle_interpret
+
+        campaign = MagicMock(spec=CampaignState)
+        state = _make_state(campaign=campaign, last_oracle_event_id=None)
+        mock_sync = MagicMock()
+        state.sync = mock_sync
+        handle_interpret(state, ["something"], set())
+        event = mock_sync.publish.call_args[0][0]
+        assert "ref" not in event.data
+
+
+# ---------------------------------------------------------------------------
+# handle_accept
+# ---------------------------------------------------------------------------
+
+
+class TestHandleAccept:
+    def test_solo_mode_shows_info(self):
+        from soloquest.commands.interpret import handle_accept
+
+        state = _make_state(campaign=None)
+        with patch("soloquest.commands.interpret.display") as mock_display:
+            handle_accept(state, [], set())
+        mock_display.info.assert_called_once()
+
+    def test_no_pending_interpretation_shows_info(self):
+        from soloquest.commands.interpret import handle_accept
+
+        campaign = MagicMock(spec=CampaignState)
+        state = _make_state(campaign=campaign)
+        state.pending_partner_interpretation = None
+        with patch("soloquest.commands.interpret.display") as mock_display:
+            handle_accept(state, [], set())
+        mock_display.info.assert_called_once()
+
+    def test_accept_logs_note_to_session(self):
+        from soloquest.commands.interpret import handle_accept
+
+        campaign = MagicMock(spec=CampaignState)
+        state = _make_state(campaign=campaign)
+        partner_event = Event(
+            player="Dax",
+            type="interpret",
+            data={"text": "the blacksmith arms rebels"},
+        )
+        state.pending_partner_interpretation = partner_event
+        handle_accept(state, [], set())
+        entries = state.session.entries
+        assert len(entries) == 1
+        assert entries[0].kind == EntryKind.NOTE
+        assert "the blacksmith arms rebels" in entries[0].text
+
+    def test_accept_publishes_acceptance_event(self):
+        from soloquest.commands.interpret import handle_accept
+
+        campaign = MagicMock(spec=CampaignState)
+        state = _make_state(campaign=campaign)
+        mock_sync = MagicMock()
+        state.sync = mock_sync
+        partner_event = Event(
+            player="Dax",
+            type="interpret",
+            data={"text": "rebels"},
+        )
+        state.pending_partner_interpretation = partner_event
+        handle_accept(state, [], set())
+        mock_sync.publish.assert_called_once()
+        published = mock_sync.publish.call_args[0][0]
+        assert published.type == "accept_interpretation"
+        assert published.data["ref"] == partner_event.id
+
+    def test_accept_clears_pending_interpretation(self):
+        from soloquest.commands.interpret import handle_accept
+
+        campaign = MagicMock(spec=CampaignState)
+        state = _make_state(campaign=campaign)
+        state.pending_partner_interpretation = Event(
+            player="Dax", type="interpret", data={"text": "x"}
+        )
+        handle_accept(state, [], set())
+        assert state.pending_partner_interpretation is None
+
+    def test_accept_logs_with_player_attribution(self):
+        from soloquest.commands.interpret import handle_accept
+
+        campaign = MagicMock(spec=CampaignState)
+        state = _make_state(campaign=campaign)
+        state.pending_partner_interpretation = Event(
+            player="Dax", type="interpret", data={"text": "something"}
+        )
+        handle_accept(state, [], set())
+        assert state.session.entries[0].player == "Kira"


### PR DESCRIPTION
## Summary

- Add `/interpret [text]` — propose what an oracle roll means in fiction. Logs immediately as a `[Interpretation]` note in both solo and co-op. In co-op, also publishes an `interpret` event referencing the triggering oracle roll UUID so partners receive it via poll
- Add `/accept` — adopt a pending partner interpretation into your session log and publish `accept_interpretation` event. Solo mode shows an informational message (interpretations are always auto-accepted)
- Track `last_oracle_event_id` in `GameState` so `/interpret` can reference the oracle that prompted it
- Track `pending_partner_interpretation` in `GameState` — set when poll returns an `interpret` event, cleared after `/accept`
- `display.partner_activity` now renders `interpret` events with a 💬 glyph and a hint to `/accept`

## Test plan

- [ ] `tests/test_interpret.py` — 13 new tests covering `/interpret` (no args, session logging, player attribution, solo/co-op publish behaviour, oracle ref) and `/accept` (solo no-op, no pending, logs note, publishes acceptance, clears state, player attribution)
- [ ] `uv run python -m pytest` — 697 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)