### PR TITLE
feat: shared campaign vows (/vow --shared and progress sync)

### DIFF
--- a/soloquest/commands/registry.py
+++ b/soloquest/commands/registry.py
@@ -102,7 +102,7 @@ COMMAND_HELP: dict[str, str] = {
     "move": "/move [name] (alias: /m) — resolve a move (e.g. /move strike)",
     "oracle": "/oracle [table] (alias: /o) — consult an oracle (e.g. /oracle action theme)  --table to view full table",
     "asset": "/asset [name] [+/-N | meter +/-N | condition] — view or update asset meters/conditions",
-    "vow": "/vow [rank] [text] (alias: /v) — create a vow",
+    "vow": "/vow [rank] [text] (alias: /v) — create a vow  --shared to make it campaign-wide",
     "progress": "/progress [vow] (alias: /p) — mark progress on a vow",
     "fulfill": "/fulfill [vow] (alias: /f) — attempt to fulfill a vow",
     "char": "/char [new] (alias: /c) — show character sheet, or /char new to start over",

--- a/soloquest/models/campaign.py
+++ b/soloquest/models/campaign.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from soloquest.models.vow import Vow
 
 
 @dataclass
@@ -28,6 +31,7 @@ class CampaignState:
     slug: str
     created: str  # ISO 8601 datetime string
     players: dict[str, PlayerInfo] = field(default_factory=dict)
+    shared_vows: list[Vow] = field(default_factory=list)  # type: ignore[type-arg]
 
     @property
     def campaign_dir(self) -> Path | None:
@@ -38,7 +42,7 @@ class CampaignState:
         self._campaign_dir = path
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        d: dict[str, Any] = {
             "campaign": {
                 "name": self.name,
                 "slug": self.slug,
@@ -46,16 +50,23 @@ class CampaignState:
             },
             "players": {pid: info.to_dict() for pid, info in self.players.items()},
         }
+        if self.shared_vows:
+            d["shared_vows"] = [v.to_dict() for v in self.shared_vows]
+        return d
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> CampaignState:
+        from soloquest.models.vow import Vow
+
         camp = d.get("campaign", d)
         players = {pid: PlayerInfo.from_dict(info) for pid, info in d.get("players", {}).items()}
+        shared_vows = [Vow.from_dict(v) for v in d.get("shared_vows", [])]
         return cls(
             name=camp["name"],
             slug=camp["slug"],
             created=camp["created"],
             players=players,
+            shared_vows=shared_vows,
         )
 
     @classmethod

--- a/soloquest/models/vow.py
+++ b/soloquest/models/vow.py
@@ -32,6 +32,7 @@ class Vow:
     rank: VowRank
     ticks: int = 0
     fulfilled: bool = False
+    shared: bool = False  # True = campaign-level vow, visible to all players
 
     @property
     def progress_score(self) -> int:
@@ -53,12 +54,15 @@ class Vow:
         return self.ticks
 
     def to_dict(self) -> dict:
-        return {
+        d: dict = {
             "description": self.description,
             "rank": self.rank.value,
             "ticks": self.ticks,
             "fulfilled": self.fulfilled,
         }
+        if self.shared:
+            d["shared"] = True
+        return d
 
     @classmethod
     def from_dict(cls, data: dict) -> Vow:
@@ -73,6 +77,7 @@ class Vow:
             rank=rank,
             ticks=data.get("ticks", 0),
             fulfilled=data.get("fulfilled", False),
+            shared=data.get("shared", False),
         )
 
 

--- a/soloquest/ui/display.py
+++ b/soloquest/ui/display.py
@@ -438,6 +438,17 @@ def partner_activity(events: list) -> None:
                 f"  [magenta]└[/magenta]  💬 [dim]interpretation:[/dim]  [italic]{text}[/italic]"
             )
             console.print("  [dim]    Type /accept to adopt this interpretation.[/dim]")
+        elif event.type == "shared_vow_created":
+            rank = event.data.get("rank", "?")
+            desc = event.data.get("description", "")
+            console.print(f"  [green]└[/green]  ⚔ [dim]shared vow sworn [{rank}]:[/dim]  {desc}")
+        elif event.type == "shared_vow_progress":
+            desc = event.data.get("description", "")
+            score = event.data.get("progress_score", 0)
+            console.print(
+                f"  [green]└[/green]  ⚔ [dim]shared vow progress:[/dim]  {desc}  "
+                f"[dim]→[/dim]  [bold]{score}/10[/bold]"
+            )
         else:
             # Generic fallback for unrecognised event types
             console.print(f"  [dim]  {event.type}: {event.data}[/dim]")

--- a/tests/test_shared_vows.py
+++ b/tests/test_shared_vows.py
@@ -1,0 +1,247 @@
+"""Tests for shared campaign vows."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from soloquest.models.campaign import CampaignState
+from soloquest.models.session import Session
+from soloquest.models.vow import Vow, VowRank
+from soloquest.sync import LocalAdapter
+
+
+def _make_state(campaign=None, campaign_dir=None, vows=None):
+    from soloquest.loop import GameState
+
+    character = MagicMock()
+    character.name = "Kira"
+
+    state = GameState(
+        character=character,
+        vows=vows or [],
+        session=Session(number=1),
+        session_count=0,
+        dice_mode=MagicMock(),
+        dice=MagicMock(),
+        moves={},
+        oracles={},
+        assets={},
+        truth_categories={},
+        sync=LocalAdapter("Kira"),
+        campaign=campaign,
+        campaign_dir=campaign_dir,
+    )
+    return state
+
+
+def _make_campaign():
+    return CampaignState(
+        name="Test Campaign",
+        slug="test-campaign",
+        created="2026-01-01T00:00:00+00:00",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Vow model
+# ---------------------------------------------------------------------------
+
+
+class TestVowSharedField:
+    def test_shared_defaults_to_false(self):
+        vow = Vow(description="Save the colony", rank=VowRank.DANGEROUS)
+        assert vow.shared is False
+
+    def test_shared_in_dict_when_true(self):
+        vow = Vow(description="Save the colony", rank=VowRank.DANGEROUS, shared=True)
+        assert vow.to_dict()["shared"] is True
+
+    def test_shared_omitted_from_dict_when_false(self):
+        vow = Vow(description="Save the colony", rank=VowRank.DANGEROUS, shared=False)
+        assert "shared" not in vow.to_dict()
+
+    def test_round_trip_preserves_shared_true(self):
+        vow = Vow(description="Save the colony", rank=VowRank.DANGEROUS, shared=True)
+        restored = Vow.from_dict(vow.to_dict())
+        assert restored.shared is True
+
+    def test_round_trip_backward_compat_no_shared_key(self):
+        data = {"description": "Old vow", "rank": "dangerous", "ticks": 0, "fulfilled": False}
+        vow = Vow.from_dict(data)
+        assert vow.shared is False
+
+
+# ---------------------------------------------------------------------------
+# CampaignState shared_vows
+# ---------------------------------------------------------------------------
+
+
+class TestCampaignStateSharedVows:
+    def test_shared_vows_defaults_empty(self):
+        campaign = _make_campaign()
+        assert campaign.shared_vows == []
+
+    def test_shared_vows_serialized_only_when_nonempty(self):
+        campaign = _make_campaign()
+        d = campaign.to_dict()
+        assert "shared_vows" not in d
+
+    def test_shared_vows_serialized_when_present(self):
+        campaign = _make_campaign()
+        campaign.shared_vows.append(Vow(description="Test", rank=VowRank.DANGEROUS, shared=True))
+        d = campaign.to_dict()
+        assert "shared_vows" in d
+        assert len(d["shared_vows"]) == 1
+
+    def test_shared_vows_round_trip(self):
+        campaign = _make_campaign()
+        campaign.shared_vows.append(
+            Vow(description="Save the colony", rank=VowRank.FORMIDABLE, ticks=8, shared=True)
+        )
+        restored = CampaignState.from_dict(campaign.to_dict())
+        assert len(restored.shared_vows) == 1
+        assert restored.shared_vows[0].description == "Save the colony"
+        assert restored.shared_vows[0].ticks == 8
+        assert restored.shared_vows[0].shared is True
+
+    def test_backward_compat_no_shared_vows_key(self):
+        """Campaigns created before shared vows deserialise without error."""
+        data = {
+            "campaign": {"name": "Test", "slug": "test", "created": "2026-01-01T00:00:00+00:00"},
+            "players": {},
+        }
+        campaign = CampaignState.from_dict(data)
+        assert campaign.shared_vows == []
+
+
+# ---------------------------------------------------------------------------
+# handle_vow with --shared flag
+# ---------------------------------------------------------------------------
+
+
+class TestHandleVowShared:
+    def test_shared_without_campaign_warns(self):
+        from soloquest.commands.vow import handle_vow
+
+        state = _make_state(campaign=None)
+        with patch("soloquest.commands.vow.display") as mock_display:
+            handle_vow(state, ["dangerous", "save", "the", "colony"], {"shared"})
+        mock_display.warn.assert_called_once()
+        assert state.vows == []
+
+    def test_shared_adds_to_campaign_shared_vows(self, tmp_path):
+        from soloquest.commands.vow import handle_vow
+
+        campaign = _make_campaign()
+        state = _make_state(campaign=campaign, campaign_dir=tmp_path)
+        # Create necessary subdirectory structure
+        (tmp_path / "events").mkdir()
+
+        with patch("soloquest.state.campaign.save_campaign"):
+            handle_vow(state, ["dangerous", "save", "colony"], {"shared"})
+
+        assert len(state.campaign.shared_vows) == 1
+        vow = state.campaign.shared_vows[0]
+        assert vow.description == "save colony"
+        assert vow.rank == VowRank.DANGEROUS
+        assert vow.shared is True
+
+    def test_shared_does_not_add_to_personal_vows(self, tmp_path):
+        from soloquest.commands.vow import handle_vow
+
+        campaign = _make_campaign()
+        state = _make_state(campaign=campaign, campaign_dir=tmp_path)
+
+        with patch("soloquest.state.campaign.save_campaign"):
+            handle_vow(state, ["dangerous", "save", "colony"], {"shared"})
+
+        assert state.vows == []
+
+    def test_shared_publishes_event(self, tmp_path):
+        from soloquest.commands.vow import handle_vow
+
+        campaign = _make_campaign()
+        state = _make_state(campaign=campaign, campaign_dir=tmp_path)
+        mock_sync = MagicMock()
+        state.sync = mock_sync
+
+        with patch("soloquest.state.campaign.save_campaign"):
+            handle_vow(state, ["formidable", "find", "the", "relic"], {"shared"})
+
+        mock_sync.publish.assert_called_once()
+        event = mock_sync.publish.call_args[0][0]
+        assert event.type == "shared_vow_created"
+        assert event.data["description"] == "find the relic"
+        assert event.data["rank"] == "formidable"
+
+    def test_unshared_vow_works_as_before(self):
+        from soloquest.commands.vow import handle_vow
+
+        state = _make_state()
+        handle_vow(state, ["dangerous", "save", "colony"], set())
+        assert len(state.vows) == 1
+        assert state.vows[0].shared is False
+
+
+# ---------------------------------------------------------------------------
+# handle_progress with shared vows
+# ---------------------------------------------------------------------------
+
+
+class TestHandleProgressSharedVows:
+    def test_progress_on_shared_vow(self, tmp_path):
+        from soloquest.commands.vow import handle_progress
+
+        campaign = _make_campaign()
+        vow = Vow(description="Find the relic", rank=VowRank.DANGEROUS, shared=True)
+        campaign.shared_vows.append(vow)
+        state = _make_state(campaign=campaign, campaign_dir=tmp_path)
+
+        with patch("soloquest.state.campaign.save_campaign") as mock_save:
+            handle_progress(state, ["relic"], set())
+
+        assert vow.ticks > 0
+        mock_save.assert_called_once()
+
+    def test_progress_on_shared_vow_publishes_event(self, tmp_path):
+        from soloquest.commands.vow import handle_progress
+
+        campaign = _make_campaign()
+        vow = Vow(description="Find the relic", rank=VowRank.DANGEROUS, shared=True)
+        campaign.shared_vows.append(vow)
+        state = _make_state(campaign=campaign, campaign_dir=tmp_path)
+        mock_sync = MagicMock()
+        state.sync = mock_sync
+
+        with patch("soloquest.state.campaign.save_campaign"):
+            handle_progress(state, ["relic"], set())
+
+        mock_sync.publish.assert_called_once()
+        event = mock_sync.publish.call_args[0][0]
+        assert event.type == "shared_vow_progress"
+
+    def test_progress_on_personal_vow_does_not_save_campaign(self):
+        from soloquest.commands.vow import handle_progress
+
+        vow = Vow(description="Personal goal", rank=VowRank.DANGEROUS)
+        state = _make_state(vows=[vow])
+
+        with patch("soloquest.state.campaign.save_campaign") as mock_save:
+            handle_progress(state, ["personal"], set())
+
+        mock_save.assert_not_called()
+
+    def test_shared_vow_shown_in_active_pool(self):
+        from soloquest.commands.vow import handle_progress
+
+        campaign = _make_campaign()
+        shared_vow = Vow(description="Shared goal", rank=VowRank.DANGEROUS, shared=True)
+        campaign.shared_vows.append(shared_vow)
+        personal_vow = Vow(description="Personal goal", rank=VowRank.TROUBLESOME)
+        state = _make_state(campaign=campaign, vows=[personal_vow])
+
+        # Both vows should be visible; resolve "shared" query matches shared vow
+        with patch("soloquest.state.campaign.save_campaign"):
+            handle_progress(state, ["shared"], set())
+
+        assert shared_vow.ticks > 0


### PR DESCRIPTION
## Summary

- Add `shared: bool = False` to `Vow` model — backward compatible (omitted from dict when False, defaults False on load)
- Add `shared_vows: list[Vow]` to `CampaignState` — serialized to `campaign.toml`, empty list when absent (backward compat)
- `/vow --shared [rank] [description]` creates a campaign-level vow stored in `campaign.toml` and publishes a `shared_vow_created` event; warns if not in a campaign
- `/progress` now searches both personal and shared vow pools; marking progress on a shared vow persists `campaign.toml` and publishes `shared_vow_progress` event
- `display.partner_activity` renders `shared_vow_created` and `shared_vow_progress` events with a ⚔ glyph inline with other partner activity

## Test plan

- [ ] `tests/test_shared_vows.py` — 19 new tests: `Vow.shared` field (serialization, round-trip, backward compat), `CampaignState.shared_vows` (empty default, serialize/deserialize, round-trip, backward compat), `/vow --shared` (no campaign guard, adds to campaign, not to personal, publishes event), `/progress` with shared vows (updates ticks, saves campaign, publishes event, personal vow skips save, shared vow in pool)
- [ ] `uv run python -m pytest` — 716 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)