### PR TITLE
chore: wire up git hooks via make install

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Pre-push hook: block direct pushes to main
+set -e
+
+current_branch=$(git symbolic-ref HEAD 2>/dev/null | sed 's|refs/heads/||')
+
+if [ "$current_branch" = "main" ]; then
+    echo "❌ Direct pushes to main are not allowed."
+    echo "   Create a feature branch and open a pull request."
+    exit 1
+fi

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ help: ## Show this help message
 	@echo "  branch NAME=x   Create and switch to new feature branch"
 	@echo "  pr              Create pull request for current branch"
 
-install: ## Install the package
+install: install-hooks ## Install the package
 	uv sync
 
 install-hooks: ## Configure git to use tracked hooks in .githooks/


### PR DESCRIPTION
## Summary
- Add `pre-push` hook to block direct pushes to `main`
- `make install` now calls `install-hooks` so new contributors get hooks configured automatically

## Test plan
- [x] Pre-commit hook ran on commit (format, lint, tests all passed)
- [x] `make install` wires up hooks via `install-hooks` dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)